### PR TITLE
Fix up stupid docs

### DIFF
--- a/docs/feature_list.md
+++ b/docs/feature_list.md
@@ -4,6 +4,7 @@ Here is a list of features in N that we have implemented and the documents that 
 
 - [Variables](./features/variables.md)
 - [Literals](./features/literals.md)
+- [Operators](./features/operators.md)
 - [Functions](./features/functions.md)
 - [Tuples, Lists, and Records](./features/tuples_lists_records.md)
 - [Destructuring](./features/destructuring.md)

--- a/docs/feature_list.md
+++ b/docs/feature_list.md
@@ -3,12 +3,15 @@
 Here is a list of features in N that we have implemented and the documents that describe them
 
 - [Variables](./features/variables.md)
+- [Literals](./features/literals.md)
 - [Functions](./features/functions.md)
 - [Tuples, Lists, and Records](./features/tuples_lists_records.md)
 - [Destructuring](./features/destructuring.md)
 - [Enums and none](./features/enums.md)
 - [If Statements](./features/if_statements.md)
+- [Match Expressions](./features/match.md)
 - [For Loops](./features/for_loops.md)
+- [While Loops, break, and continue](./features/while_loops.md)
 - [Internal Libraries](./features/internal_libraries.md)
 - [Importing .n files](./features/importing_n_files.md)
 - [Native Functions](./features/native_functions.md)
@@ -17,3 +20,4 @@ Here is a list of features in N that we have implemented and the documents that 
 - [Classes](./features/classes.md)
 - [Async](./features/async.md)
 - [Type Variables](./features/generic.md)
+- [Assert](./features/asssert.md)

--- a/docs/features/aliases.md
+++ b/docs/features/aliases.md
@@ -1,5 +1,6 @@
 # Type Aliases
 
+Type Aliases are great ways of compessing types into a more friendly form for usage in functions and other type declarations. It can be used as so:
 ```js
 // This will create a simple alias for a record type
 alias test = {
@@ -8,9 +9,27 @@ alias test = {
 	c:str,
 }
 
-let test2:test = {a:1, b:1, c:"test"}
-// This is useful for shortening down big types when you want to make it clear what type it is based off of code
+let test2 = [val:test] -> () {
+	print(val.b)
+}
 ```
+Here it may not seem that useful but when dealing with many different complex records and functions it is very useful to help figure out the types for everything. The `websocket` library uses this to help it make itself a bit more consise
+```js
+import websocket // Used for connecting to WebSockets
+let websocketTest = websocket.connect({
+  onOpen: [send: websocket.send] -> cmd[bool] {
+    print("Open!")
+    let _ = send("hi")!
+    return false
+  },
+  onMessage: [send: websocket.send message: str] -> cmd[bool] {
+    print(message)
+    let _ = send("hello")!
+    return message == "hello"
+  }
+}, "wss://echo.websocket.org")!
+```
+In this example `websocket.send` is acutally a type alias for `str -> cmd[()]`. Here is is small but it is also useful to changing the type of many different, similar records if changes are needed, such as a `user` record to add another field, as it would be impractical and problematic to do it by hand.
 
 ## Notes:
 - When printing out the type of a value that uses an alias as its type, it will not print out the alias' name.

--- a/docs/features/aliases.md
+++ b/docs/features/aliases.md
@@ -29,7 +29,7 @@ let websocketTest = websocket.connect({
   }
 }, "wss://echo.websocket.org")!
 ```
-In this example `websocket.send` is acutally a type alias for `str -> cmd[()]`. Here is is small but it is also useful to changing the type of many different, similar records if changes are needed, such as a `user` record to add another field, as it would be impractical and problematic to do it by hand.
+In this example `websocket.send` is actually a type alias for `str -> cmd[()]`. Here it is small, but it is also useful for changing the type of many different, similar records if changes are needed, such as a `user` record to add another field, as it would be impractical and problematic to do it by hand.
 
 ## Notes:
 - When printing out the type of a value that uses an alias as its type, it will not print out the alias' name.

--- a/docs/features/aliases.md
+++ b/docs/features/aliases.md
@@ -1,6 +1,6 @@
 # Type Aliases
 
-Type Aliases are great ways of compessing types into a more friendly form for usage in functions and other type declarations. It can be used as so:
+Type aliases are great ways of compressing types into a more friendly form for usage in functions and other type declarations. It can be used as so:
 ```js
 // This will create a simple alias for a record type
 alias test = {

--- a/docs/features/assert.md
+++ b/docs/features/assert.md
@@ -12,7 +12,7 @@ if let <yes mod> = intoModule(imp "./test.n") {
 	print(getUnitTestResults(mod))
 }
 ```
-For more info on these functions please see the [native functions documentation](./native_functions.md). N uses assert internally for its type and value based checks. You are able to see them in the `tests/assertions` folder in the `N-lang` repo.
+For more info on these functions please see the [native functions documentation](./native_functions.md). N uses assert internally for its type- and value-based checks. You are able to see them in the `tests/assertions` folder in the `N-lang` repo.
 
 
 ## Notes:

--- a/docs/features/assert.md
+++ b/docs/features/assert.md
@@ -1,0 +1,19 @@
+# Assert
+
+assert is a powerful tool to help with unit tests in software, they are able to not only check the type of any value or variable, but they are also able to assert the value of it too. This is mostly useful in situations where you want to unit test N files. There are two versions, assert value and assert type, they work as so:
+```js
+assert type 1: int
+
+assert value 1 + 1 = 2
+```
+During compile and execution the results of these tests are stored and can be accessed by any file that imports them as so:
+```js
+if let <yes mod> = intoModule(imp "./test.n") {
+	print(getUnitTestResults(mod))
+}
+```
+For more info on these functions please see the [native functions documentation](./native_functions.md). N uses assert internally for its type and value based checks. You are able to see them in the `tests/assertions` folder in the `N-lang` repo.
+
+
+## Notes:
+- assert value takes in a `bool`

--- a/docs/features/async.md
+++ b/docs/features/async.md
@@ -1,20 +1,139 @@
-# Async
+# Procedures
+
+In N, all functions aim to be pure and free of side effects. Given the same
+input values, a function should always return the same output. This has several
+benefits:
+
+- Functions can be silently evaluated for debugging or eager evaluation (in a
+  REPL, for example) without causing side effects and changing the behaviour of
+  the program. That is, the program won't notice whether its functions are being
+  called more than once.
+
+- Function return values can be cached (memoized) without changing how the
+  program behaves (other than performance and memory use)
+
+- Tests can run reliably and the same every time they're run.
+
+- A compiler can optimise code by removing or caching unnecessary function
+  calls.
+
+Of course, pure functions can't do everything. For example, reading from a file
+might give a different result each time. For these cases, N provides a special
+built-in type `cmd` (short for "command"), which are used for any procedure that
+has an unreliable return value or cannot be reliably optimised away if the
+return value is unused.
+
+Functions that return `cmd` values are known as "procedures." Procedures
+themselves are still pure; given the same inputs, they will still return the
+same `cmd` value. However, the `cmd` can be defined to return different values
+depending on the resulting values from other `cmd`s.
+
+**IMPORTANT**: These `cmd` values do not do anything on their own; simply
+calling `FileIO.read` as a normal function will not do anything. Rather, the
+main file being run will export the `cmd` value to the N using `let pub`. Then,
+N will execute the commands encoded inside the `cmd` value.
+
+For example, the following code reads a file named `hello.txt` using
+`FileIO.read` from the built-in `FileIO` module. The contents of the file could
+be anything—the file could also not exist! Thus, `FileIO.read` returns a `cmd`
+value that has a result type of `maybe[str]`; this is represented in a function return type annotation as `cmd[maybe[str]]`.
 
 ```js
-// Async is used with the cmd type and the await operator to run things asynchronously
+import FileIO
 
-let asyncFunction = [message:str] -> cmd[str] {
-	print(message)
-	return message
-} // Declares an async function that simply prints out a message
-
-let asyncHelper = [] -> cmd[()] {
-	let _ = asyncFunction("test")! // ! calls an async function and awaits for it to finish
+let printFile = [maybeFile: maybe[str]] -> cmd[()] {
+	if let <yes contents> = maybeFile {
+		print(contents)
+	} else {
+		print("hello.txt does not exist!")
+	}
 }
 
-let pub _ = asyncHelper()
+let pub mainCmd = FileIO.read("hello.txt")
+	|> then(printFile)
 ```
 
-## Notes
-- The `!` operator is an expression, not a command
-- The `!` operator can only be used inside a `cmd`
+Above, we use `FileIO.read("hello.txt")` to get a `cmd` value. This function
+call alone does not read the file. Instead, we create a new `cmd` value using
+the built-in `then` function that, when given the result from `FileIO.read`'s
+`cmd` value, will give the resulting value to a procedure (in this case
+`printFile`) to create a new `cmd` value to execute next.
+
+Note that although `printFile` has a return type of `cmd[()]`, it has no
+`return` statement. In N, functions with a return type of `cmd[()]` or `()` will
+implicitly return the value of the correct type at the end of the function.
+
+Finally, we set `mainCmd` to the resulting `cmd` value, and then export it with
+`pub`, so N can access and execute the command.
+
+The `then` function can be unwieldy to use, however. Fortunately, N provides
+syntactic sugar for chaining `cmd` values one after another using the `!`
+("bang") operator.
+
+```js
+import times
+import FileIO
+
+let main = [] -> cmd[()] {
+	FileIO.write(
+		"fruit.txt",
+		"It has been "
+			+ intInBase10(floor(times.getTime()!))
+			+ "ms since the UNIX epoch.",
+	)!
+	for (fruit in ["apple", "orange", "banana"]) {
+		times.sleep(1000)!
+		FileIO.append("fruit.txt", fruit)!
+	}
+}
+
+let pub mainCmd = main()
+```
+
+The `!` operator can only be used inside procedures—functions that return a
+`cmd` value, and they can only be used on other `cmd` values. This is syntactic
+sugar for pausing the function while the `cmd` is being executed, then
+continuing the rest of the function with the resulting value. You can see how
+the resulting value from the command returned by `times.getTime` is used to
+write the number of milliseconds since the UNIX epoch to a file.
+
+**IMPORTANT**: Do not forget to use `!` on `cmd` values to execute them inside
+procedures. Omitting it will simply return the `cmd` value and discard it, like
+the following:
+
+```js
+times.sleep(1000)
+```
+
+**NOTE**: The Python implementation does not support the use of `!` in
+statements. In order to sleep for 1000 milliseconds, one must write the
+following, discarding the `()` result from `times.sleep`'s command.
+
+```js
+let _ = times.sleep(1000)!
+```
+
+However, if possible, avoid writing code this way, as it is error-prone. The
+type checker can help catch accidental omissions of the `!` operator, but `let _
+=` implies that the omission is intentional.
+
+Remember that because functions have to be pure, non-procedural functions cannot
+call procedures. For this reason, you cannot use the `!` operator outside of
+procedures; that is, the `!` operator can only be used inside functions that
+return a `cmd` value.
+
+## A note on `print`
+
+`print` is quite an oddball function because it produces a side effect—it prints
+text to standard output. Thus, whether or not `print` is called an extra time is
+noticeable.
+
+`print` is primarily used for debugging, to see if a value during runtime is
+correct or if code in a procedure is reached properly. This way, `print` can be
+used inside non-procedural functions without the use of the `!` operator.
+However, in production, lone `print` statements may be optimised away because it
+is seen as a pure function.
+
+There is currently no reliable way to print text to stdout. Perhaps teh built-in
+module `SystemIO` may one day have a reliable `print` procedure that returns a
+`cmd` value to ensure it does not get optimised away.

--- a/docs/features/async.md
+++ b/docs/features/async.md
@@ -20,7 +20,7 @@ benefits:
 Of course, pure functions can't do everything. For example, reading from a file
 might give a different result each time. For these cases, N provides a special
 built-in type `cmd` (short for "command"), which is used for any procedure that
-has an unreliable return value or cannot be reliably optimised away if the
+has an unreliable return value or cannot be reliably optimized away if the
 return value is unused.
 
 Functions that return `cmd` values are known as "procedures." Procedures

--- a/docs/features/async.md
+++ b/docs/features/async.md
@@ -5,7 +5,7 @@ input values, a function should always return the same output. This has several
 benefits:
 
 - Functions can be silently evaluated for debugging or eager evaluation (in a
-  REPL, for example) without causing side effects and changing the behaviour of
+  REPL, for example) without causing side effects and changing the behavior of
   the program. That is, the program won't notice whether its functions are being
   called more than once.
 

--- a/docs/features/async.md
+++ b/docs/features/async.md
@@ -114,8 +114,7 @@ let _ = times.sleep(1000)!
 ```
 
 However, if possible, avoid writing code this way, as it is error-prone. The
-type checker can help catch accidental omissions of the `!` operator, but `let _
-=` implies that the omission is intentional.
+type checker can help catch accidental omissions of the `!` operator, but `let _ =` implies that the omission is intentional.
 
 Remember that because functions have to be pure, non-procedural functions cannot
 call procedures. For this reason, you cannot use the `!` operator outside of
@@ -134,6 +133,8 @@ used inside non-procedural functions without the use of the `!` operator.
 However, in production, lone `print` statements may be optimised away because it
 is seen as a pure function.
 
-There is currently no reliable way to print text to stdout. Perhaps teh built-in
-module `SystemIO` may one day have a reliable `print` procedure that returns a
-`cmd` value to ensure it does not get optimised away.
+There is currently no reliable way to print text to stdout. In older versions of
+N, one could use the `fek` module's `paer` procedure, but this has been removed
+in later versions. Perhaps the built-in module `SystemIO` may one day have a
+reliable `print` procedure that returns a `cmd` value to ensure it does not get
+optimised away.

--- a/docs/features/async.md
+++ b/docs/features/async.md
@@ -19,7 +19,7 @@ benefits:
 
 Of course, pure functions can't do everything. For example, reading from a file
 might give a different result each time. For these cases, N provides a special
-built-in type `cmd` (short for "command"), which are used for any procedure that
+built-in type `cmd` (short for "command"), which is used for any procedure that
 has an unreliable return value or cannot be reliably optimised away if the
 return value is unused.
 

--- a/docs/features/async.md
+++ b/docs/features/async.md
@@ -14,7 +14,7 @@ benefits:
 
 - Tests can run reliably and the same every time they're run.
 
-- A compiler can optimise code by removing or caching unnecessary function
+- A compiler can optimize code by removing or caching unnecessary function
   calls.
 
 Of course, pure functions can't do everything. For example, reading from a file

--- a/docs/features/async.md
+++ b/docs/features/async.md
@@ -130,7 +130,7 @@ noticeable.
 `print` is primarily used for debugging, to see if a value during runtime is
 correct or if code in a procedure is reached properly. This way, `print` can be
 used inside non-procedural functions without the use of the `!` operator.
-However, in production, lone `print` statements may be optimised away because it
+However, in production, lone `print` statements may be optimized away because it
 is seen as a pure function.
 
 There is currently no reliable way to print text to stdout. In older versions of

--- a/docs/features/async.md
+++ b/docs/features/async.md
@@ -137,4 +137,4 @@ There is currently no reliable way to print text to stdout. In older versions of
 N, one could use the `fek` module's `paer` procedure, but this has been removed
 in later versions. Perhaps the built-in module `SystemIO` may one day have a
 reliable `print` procedure that returns a `cmd` value to ensure it does not get
-optimised away.
+optimized away.

--- a/docs/features/classes.md
+++ b/docs/features/classes.md
@@ -18,7 +18,7 @@ class pub Sheep [colour:str age:float name:str] {
 ```
 
 To create a class, start with the `class` keyword. You can make the class public
-by adding the `pub` keyword, like you would for variables and types. Making the
+by adding the `pub` keyword like you would for variables and types. Making the
 class public will export both the type and constructor.
 
 After the keywords, specify the class name (in the above example, `Sheep`) and

--- a/docs/features/classes.md
+++ b/docs/features/classes.md
@@ -23,7 +23,7 @@ class public will export both the type and constructor.
 
 After the keywords, specify the class name (in the above example, `Sheep`) and
 the arguments for the constructor, which have the same syntax as a function
-expression. By convention, class names are capitalised.
+expression. By convention, class names are capitalized.
 
 Then, enclosed in curly brackets (`{` and `}`) is the class body. The same
 statements that you can find in a normal N file can be placed inside a class

--- a/docs/features/classes.md
+++ b/docs/features/classes.md
@@ -1,16 +1,134 @@
 # Classes
 
-```js
-// This will create a simple public class that takes in two ints and has a public function and a private function
-class pub Test [a:int b:int] {
-	let pub sum = [] -> int {
-		return a + b
-	} // This uses a and b from the first line of the class as they are internal variables
+Like a few programming languages, N has classes.
 
-	let internalSum = a + b // This is private
+```js
+/// A sheep.
+class pub Sheep [colour:str age:float name:str] {
+	/// The display name for the type of sheep based on its wool colour.
+	let typeName = colour + " sheep"
+
+	/// Create a new Sheep with the given name
+	let pub rename = [newName:str] -> Sheep {
+		return Sheep(colour, age, newName)
+	}
+
+	let pub introduction = "Hi, I'm " + name + ", and I am a " + typeName + "."
 }
 ```
 
-## Notes:
-- There is currently no way for multiple contructors.
-- All things in a class are automatically private, this does include the values passed in.
+To create a class, start with the `class` keyword. You can make the class public
+by adding the `pub` keyword, like you would for variables and types. Making the
+class public will export both the type and constructor.
+
+After the keywords, specify the class name (in the above example, `Sheep`) and
+the arguments for the constructor, which have the same syntax as a function
+expression. By convention, class names are capitalised.
+
+Then, enclosed in curly brackets (`{` and `}`) is the class body. The same
+statements that you can find in a normal N file can be placed inside a class
+body, so you can call `print` or define variables.
+
+You can define public properties and methods—accessible outside the class
+body—using the `pub` keyword.
+
+```js
+let billy = Sheep("white", 5, "Billy")
+
+assert value billy.rename("Bob").introduction
+	== "Hi, I'm Bob, and I am a white sheep."
+```
+
+To create an instance of a class, you can call the class name like a function,
+specifying the constructor's arguments. The class constructor is a normal
+function, so you can curry it.
+
+Class instances are records, so you can access public properties and methods
+using dot (`.`) notation. `billy.typeName` would be a type error in the above
+example because `typeName` is not a public property (it is private).
+
+## Representation of classes in N
+
+In reality, N classes are syntactic sugar for functions that return a record.
+For example, the above example is equivalent to the following:
+
+```js
+alias pub Sheep = {
+	rename: str -> Sheep
+	introduction: str
+}
+
+let pub Sheep = [colour:str age:float name:str] -> Sheep {
+	let typeName = colour + " sheep"
+
+	let pub rename = [newName:str] -> Sheep {
+		return Sheep(colour, age, newName)
+	}
+
+	let pub introduction = "Hi, I'm " + name + ", and I am a " + typeName + "."
+
+	return {
+		rename
+		introduction
+	}
+}
+```
+
+A few keen readers among you may note that this means that class types are
+merely aliases of record types. This means that classes are structurally typed,
+not nominally typed, like TypeScript. This allows for duck-typing: if the class instance walks like a duck and quacks like a duck, then it must be a duck.
+
+Thus, the following code is valid and free of type errors.
+
+```js
+class Duck [] {
+	let pub walk = "Waddle waddle."
+
+	let pub quack = "Quack. Got any grapes?"
+}
+
+class Human [] {
+	let pub walk = "I am walking."
+
+	let pub quack = "\"Quack.\""
+}
+
+// This is valid.
+let definitelyADuck: Duck = Human()
+```
+
+## Recommended idiomatic patterns
+
+When working with classes in N, here are some suggested coding patterns to meet
+various needs.
+
+### Private constructors
+
+To make only the class constructor private while exporting the class type, you
+will have to give the class a different name, then export a type alias for the
+unexported class name.
+
+```js
+class Sheep_ [...] { ... }
+
+alias pub Sheep = Sheep_
+```
+
+### Multiple constructors
+
+To support multiple constructors, you can instead make helper functions as
+static methods separate from the class that construct the class. Optionally, you
+can make the main class constructor private and only export the helper
+functions.
+
+In the `Sheep` example, we can export a function `makeBlackSheep`, taking
+advantage of currying, which constructs a black sheep.
+
+```js
+let pub makeBlackSheep = Sheep("black")
+```
+
+## Limitations
+
+Unlike other object-oriented languages, N does not support class inheritance
+yet.

--- a/docs/features/currying.md
+++ b/docs/features/currying.md
@@ -1,9 +1,7 @@
 # Currying and the Pipe Operator
 
+Currying is a useful way of pre-filling arguments in functions to stop the need of having to copy an argument serveral times. Currying occurs when a function is called with less arguments then it takes in, creating a new function that takes in the arguments that were not filled, and pre-filled values based on the arguments that were passed in. Here is an example of currying:
 ```js
-// Currying is when a function is called with less arguments than intended
-// When calling a function with fewer arguments than it can take, it will return a new function that calls the old function, but with the arguments already given pre-filled.
-
 let sum = [a:int b:int] -> int {
 	return a + b
 }
@@ -11,11 +9,11 @@ let sum = [a:int b:int] -> int {
 let addOne = sum(1) // Here it is called with one less argument than intended; this ends up returning a function that is an int -> int, which when called will add one to the number
 
 print(addOne(2)) // Prints 3
-
-// The pipe operator takes in a value on the left side and a function on the right side, and calls the function with the value on the left side
-
+```
+The `|>` operator goes well with currying as it takes in a function on the right side and applies the arugment on the left to the function on the right, allowing for useages like this:
+```js
 2
- |> sum(1)
+ |> sum(1) // Same as sum(1, 2) or sum(1)(2)
  |> print // Note that the pipe operator can be stacked indefinitely. This still prints 3
 ```
 

--- a/docs/features/currying.md
+++ b/docs/features/currying.md
@@ -10,7 +10,7 @@ let addOne = sum(1) // Here it is called with one less argument than intended; t
 
 print(addOne(2)) // Prints 3
 ```
-The `|>` operator goes well with currying as it takes in a function on the right side and applies the arugment on the left to the function on the right, allowing for useages like this:
+The `|>` operator goes well with currying as it takes in a function on the right side and applies the argument on the left to the function on the right, allowing for usages like this:
 ```js
 2
  |> sum(1) // Same as sum(1, 2) or sum(1)(2)

--- a/docs/features/currying.md
+++ b/docs/features/currying.md
@@ -1,6 +1,6 @@
 # Currying and the Pipe Operator
 
-Currying is a useful way of pre-filling arguments in functions to stop the need of having to copy an argument serveral times. Currying occurs when a function is called with less arguments then it takes in, creating a new function that takes in the arguments that were not filled, and pre-filled values based on the arguments that were passed in. Here is an example of currying:
+Currying is a useful way of pre-filling arguments in functions to stop the need of having to copy an argument several times. Currying occurs when a function is called with fewer arguments than it takes in, creating a new function that takes in the arguments that were not filled, and pre-filled values based on the arguments that were passed in. Here is an example of currying:
 ```js
 let sum = [a:int b:int] -> int {
 	return a + b

--- a/docs/features/destructuring.md
+++ b/docs/features/destructuring.md
@@ -3,8 +3,7 @@
 Destructuring is the main way to get items out of tuples and can be used inside an `if` statment to check whether or not a destucurable type fits a certain pattern. There are two different types of detructuring:
 
 ```js
-let a,
-  b = (1, 2) // Sets a and b to 1 and 2 respectively
+let a,   b = (1, 2) // Sets a and b to 1 and 2 respectively
 let { a, c: b } = { a: 1, c: 1 } // Sets a and c in the record to a and b respectively
 ```
 

--- a/docs/features/destructuring.md
+++ b/docs/features/destructuring.md
@@ -1,13 +1,13 @@
 # Destructuring
 
+Destructuring is the main way to get items out of tuples and can be used inside an `if` statment to check whether or not a destucurable type fits a certain pattern. There are two different types of detructuring:
+
 ```js
-// Destructuring is the main way to get values out of a tuple and is used for conditional lets
-
 let a, b = (1, 2) // Sets a and b to 1 and 2 respectively
-
 let { a, c: b } = { a: 1, c: 1 } // Sets a and c in the record to a and b respectively
-
-
+```
+This is a direct destructure, which can only be done with tuples and records, as they have defined fields or types.
+```js
 if let [a, b] = [1, 2] { // If it is able to destructure then it runs the code
 	print(a)
 	print(b)
@@ -17,6 +17,26 @@ if let [a, b] = [1, 2] { // If it is able to destructure then it runs the code
 
 if let <yes a> = yes("test") { // Sets a to "test" as it managed to destructure correctly, so it is not a maybe
 	print(a)
+}
+```
+The next type of destrucuting is the conditional `let`, as this is the only time list destructuring or enum destrucuring can be used. This is very useful for dealing with json types:
+```js
+import json
+let jsonToStrMap = [val:json.value] -> maybe[map[str, str]] {
+	if let <object valueMap> = val { // Checks if val is a json.object and stores it in valueMap if it is
+		return entries(map) // For each of the entries in the map run the following code 
+			|> filterMap(([(key, value): (str, json.value)] -> maybe[(str, str)] {
+				if let <string str> = value { // If the value in the map can be turned into a json.string then run the following code
+					return yes((key, str))
+				} else {
+					return none // If it is not a json.string then remove it from the map
+				}
+			}))
+			|> mapFrom()
+			|> yes()
+	} else {
+		return none // If the value is not a json.object then return none
+	}
 }
 ```
 

--- a/docs/features/destructuring.md
+++ b/docs/features/destructuring.md
@@ -3,7 +3,7 @@
 Destructuring is the main way to get items out of tuples and can be used inside an `if` statment to check whether or not a destucurable type fits a certain pattern. There are two different types of detructuring:
 
 ```js
-let a,   b = (1, 2) // Sets a and b to 1 and 2 respectively
+let a, b = (1, 2) // Sets a and b to 1 and 2 respectively
 let { a, c: b } = { a: 1, c: 1 } // Sets a and c in the record to a and b respectively
 ```
 

--- a/docs/features/destructuring.md
+++ b/docs/features/destructuring.md
@@ -3,10 +3,13 @@
 Destructuring is the main way to get items out of tuples and can be used inside an `if` statment to check whether or not a destucurable type fits a certain pattern. There are two different types of detructuring:
 
 ```js
-let a, b = (1, 2) // Sets a and b to 1 and 2 respectively
+let a,
+  b = (1, 2) // Sets a and b to 1 and 2 respectively
 let { a, c: b } = { a: 1, c: 1 } // Sets a and c in the record to a and b respectively
 ```
+
 This is a direct destructure, which can only be done with tuples and records, as they have defined fields or types.
+
 ```js
 if let [a, b] = [1, 2] { // If it is able to destructure then it runs the code
 	print(a)
@@ -19,12 +22,16 @@ if let <yes a> = yes("test") { // Sets a to "test" as it managed to destructure 
 	print(a)
 }
 ```
+
+## Conditional patterns
+
 The next type of destrucuting is the conditional `let`, as this is the only time list destructuring or enum destrucuring can be used. This is very useful for dealing with json types:
+
 ```js
 import json
 let jsonToStrMap = [val:json.value] -> maybe[map[str, str]] {
 	if let <object valueMap> = val { // Checks if val is a json.object and stores it in valueMap if it is
-		return entries(map) // For each of the entries in the map run the following code 
+		return entries(map) // For each of the entries in the map run the following code
 			|> filterMap(([(key, value): (str, json.value)] -> maybe[(str, str)] {
 				if let <string str> = value { // If the value in the map can be turned into a json.string then run the following code
 					return yes((key, str))
@@ -41,4 +48,5 @@ let jsonToStrMap = [val:json.value] -> maybe[map[str, str]] {
 ```
 
 ## Notes
+
 - All destructuring types can be used with a conditional let.

--- a/docs/features/for_loops.md
+++ b/docs/features/for_loops.md
@@ -1,6 +1,6 @@
 # For Loops
 
-For loops are a great way to run code a certain or changing amount of ways in a consice manner. For example, here is a for loop that `print`s all of the numbers 0-9
+For loops are a great way to run code a certain or changing amount of ways in a concise manner. For example, here is a for loop that `print`s all of the numbers 0-9
 ```js
 for (i in range(0, 10, 1)) { // range takes in a lower bound (inclusive), and upperbound (exclusive), and a step size are returns an int array
 	print(i)

--- a/docs/features/for_loops.md
+++ b/docs/features/for_loops.md
@@ -24,7 +24,7 @@ is
 a
 test
 ```
-This is not only limited to list literals as we have seen, making it a useful feature to read evey item in a list.
+This is not only limited to list literals as we have seen, making it a useful feature to read every item in a list.
 
 ## Notes:
 - Currently the only iterables that are registered are `list` values

--- a/docs/features/for_loops.md
+++ b/docs/features/for_loops.md
@@ -27,5 +27,5 @@ test
 This is not only limited to list literals as we have seen, making it a useful feature to read every item in a list.
 
 ## Notes:
-- Currently the only iterables that are registered are `list` values
+- Currently, the only iterables that are registered are `list` values
 - The old syntax will still run, but will give a deprecation warning

--- a/docs/features/for_loops.md
+++ b/docs/features/for_loops.md
@@ -11,7 +11,7 @@ This is not all that the `for` loop can do. As you saw, the for loop above used 
 range(0, 10, 1) // [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 range(0, 10, 2) // [0, 2, 4, 6, 8]
 ```
-This is used in the `for` loop example as the `for` loop iterates through each item in the `list`, setting `i` to the next item in the list before each cycle, allowing for useage of the `for` loop like so:
+This is used in the `for` loop example as the `for` loop iterates through each item in the `list`, setting `i` to the next item in the list before each cycle, allowing for usage of the `for` loop like so:
 ```js
 for (i in ["this", "is", "a", "test"]) {
 	print(i)

--- a/docs/features/for_loops.md
+++ b/docs/features/for_loops.md
@@ -2,7 +2,7 @@
 
 For loops are a great way to run code a certain or changing amount of ways in a concise manner. For example, here is a for loop that `print`s all of the numbers 0-9
 ```js
-for (i in range(0, 10, 1)) { // range takes in a lower bound (inclusive), and upperbound (exclusive), and a step size are returns an int array
+for (i in range(0, 10, 1)) { // range takes in a lower bound (inclusive), and upper bound (exclusive), and a step size are returns an int array
 	print(i)
 } // This will print 0 - 9
 ```

--- a/docs/features/for_loops.md
+++ b/docs/features/for_loops.md
@@ -1,24 +1,30 @@
 # For Loops
 
+For loops are a great way to run code a certain or changing amount of ways in a consice manner. For example, here is a for loop that `print`s all of the numbers 0-9
 ```js
-// Simple for loop that prints out 0 though 9
-// for loops take in a name and an optional type and a list value and will iterate thought the list value
-
 for (i in range(0, 10, 1)) { // range takes in a lower bound (inclusive), and upperbound (exclusive), and a step size are returns an int array
 	print(i)
 } // This will print 0 - 9
-
-/*
-for i 10 {
-	print(i)
-} // deprecated
-*/
-
-// range can be replaced with any iterable
-for (i in ["a", "b", "c"]) {
+```
+This is not all that the `for` loop can do. As you saw, the for loop above used the `range` function, which is an internal function that takes in a lower bound, upper bound, and a step parameter and it will return a `list` with numbers from the lower bound (inclusive) and the upper bound (exclusive) with differences of the step variable like so:
+```js
+range(0, 10, 1) // [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+range(0, 10, 2) // [0, 2, 4, 6, 8]
+```
+This is used in the `for` loop example as the `for` loop iterates through each item in the `list`, setting `i` to the next item in the list before each cycle, allowing for useage of the `for` loop like so:
+```js
+for (i in ["this", "is", "a", "test"]) {
 	print(i)
 }
 ```
+This ends up outputting
+```
+this
+is
+a
+test
+```
+This is not only limited to list literals as we have seen, making it a useful feature to read evey item in a list.
 
 ## Notes:
 - Currently the only iterables that are registered are `list` values

--- a/docs/features/functions.md
+++ b/docs/features/functions.md
@@ -86,7 +86,7 @@ lacking an explicit `return` statement.
 }
 ```
 
-**NOTE**: The above function may be optimised and never called during runtime
+**NOTE**: The above function may be optimized and never called during runtime
 because its return value is known at compile time (unit types only have one
 possible value during runtime).
 

--- a/docs/features/functions.md
+++ b/docs/features/functions.md
@@ -1,20 +1,245 @@
 # Functions
 
+In N, functions are a type of value, like strings or lists. This means they
+can be stored in variables or passed around as arguments for or return values
+from another function.
+
+As a preview for what this article entails, the following code defines a
+function named `getPi` that takes a `()` (the unit type) and returns a float.
+Then, `getPi` is called and printed.
+
 ```js
-// Declare a function that takes in 2 arguments and returns the sum of them
-let test = [a:int b:int] -> int {
-	return a + b
-} // The type of this is int -> int -> int
+let getPi = [] -> float {
+	return 3.141592653589793
+}
 
-
-let test2 = test(1, 2)
-
-print(test)
-print(test2)
-
-print(type(test)) // This print out `int -> int -> int`
+print(getPi())
 ```
 
-## Notes:
-- The type of a function is `[type of argument 1] -> [type of argument 2] -> ... -> [return type]`
-- The value of a function is an expression so this is what anonymous functions are commonly used as
+The above definition benefits from type inference and syntactic sugar. The
+following code is a more verbose equivalent of the above example.
+
+```js
+let getPi: () -> float = [_: ()] -> float {
+	return 3.141592653589793
+}
+
+print(getPi(()))
+```
+
+## Function expressions
+
+The following is an example of a function expression. This alone does not make
+the function expression usable; it needs to be stored somewhere before it can be
+called.
+
+```js
+[a:float b:float] -> float {
+	return (a^2 + b^2)^0.5
+}
+```
+
+Function expressions start with a list of arguments, separated by spaces and
+enclosed by square brackets. Each argument consists of a [definite
+pattern](./destructuring.md), which can just be the argument name, followed by a
+colon (`:`) then the type annotation of the argument. Note that unlike `let`
+statements, argument type annotations cannot be inferred and thus are required.
+In the example above, the function expression has two arguments: `a` and `b`,
+both floats.
+
+After the arguments, there is an arrow (`->`) and then the return type
+annotation. Like the function arguments, the return type annotation cannot be
+inferred and is thus also required. In the above example, the function returns a
+float.
+
+Then, after the return type is the body of the function: statements enclosed by
+curly brackets (`{` and `}`).
+
+**NOTE**: N supposedly has "anonymous function expressions" that use a colon
+(`:`) after the return type. You would expect the documentation to document
+this, but there's not that much information on it even for the people writing
+this, and it seems the implementations don't agree on it. There're also no tests
+specifying its behaviour and syntax.
+
+Functions are required to `return` a value with the proper type by the end of
+the function.
+
+### Syntactic sugar for `()`
+
+If the function expression has no arguments, the function is assumed to take a
+`()`, a unit value.
+
+```ts
+assert type [] -> int {
+	return 3
+} : () -> int
+```
+
+A function with a return type of `()` or `cmd[()]` does not need a `return`
+statement. There is an implicit `return ()` at the end of the function for
+convenience. The following example is valid, despite the function expression
+lacking an explicit `return` statement.
+
+```js
+[] -> () {
+	print("Hello")
+}
+```
+
+**NOTE**: The above function may be optimised and never called during runtime
+because its return value is known at compile time (unit types only have one
+possible value during runtime).
+
+### Declaring functions
+
+Unlike many programming languages, N does not have a special syntax for
+declaring functions. Instead, you can store the function in a variable like with
+any other value using a `let` statement. You can take advantage of type inference to avoid redundantly listing types.
+
+The following code declares a function `add` that takes two integers and returns
+an integer.
+
+```ts
+let add = [a:int b:int] -> int {
+	return a + b
+}
+```
+
+## Calling functions
+
+In the `add` example above, `add` in reality is a function that takes an
+integer, then returns another function that takes another integer before
+returning an integer. This is called **currying**; in N, all functions are
+curried, so functions will take one argument at a time.
+
+Thus, it is perfectly valid to only give one argument to `add` for **partial
+application**.
+
+```ts
+let addOne = add(1)
+```
+
+`addOne` is a function that takes a single integer and returns the integer
+incremented by one.
+
+```js
+assert value addOne(3) == 4
+assert value addOne(-2) == -1
+```
+
+Currying and partial application are useful for creating more specific functions
+that can operate on values with certain options preset. For this reason, it is
+good practice in N to have any options arguments as the first arguments for a
+function, then the value to transform as the last argument.
+
+The built-in function `itemAt` is a good example of this practice. It takes an
+index first, then the list. Thus, a more specific function that gets the first
+or second item of a list can be easily defined by only supplying an index to the
+`itemAt`.
+
+```js
+let first = itemAt(0)
+let second = itemAt(1)
+```
+
+### Type annotations
+
+To demonstrate that functions with multiple arguments actually take one argument
+at a time and then return another function, the type annotation of the `add`
+function from above is `int -> (int -> int)`.
+
+```ts
+assert type add : int -> int -> int
+```
+
+**NOTE**: The parentheses are optional if the return type of a function is
+another function. However, if the argument type is a function, then parentheses
+are needed. For example, `str -> (str -> str)` is a function that takes two
+strings, while `(str -> str) -> str` is a function that takes another function
+that takes a string.
+
+Here are a few other examples with other functions defined in the examples
+above. Some of these type annotations use type variables, which you can read
+about at [Type variables](./generic.md).
+
+```ts
+assert type [a:float b:float] -> float {
+	return (a^2 + b^2)^0.5
+} : float -> float -> float
+
+assert type [] -> () {
+	print("Hello")
+} : () -> ()
+
+assert type addOne : int -> int
+
+assert type first : [t] list[t] -> maybe[t]
+assert type second : [t] list[t] -> maybe[t]
+```
+
+**TL;DR**: You can think of function type annotations as `[argument 1] -> [argument 2] -> ... -> [return type]`.
+
+### Calling functions with multiple arguments at once
+
+`substring` is a built-in function that takes a start index (inclusive), end
+index (exclusive), then a string to slice.
+
+Since functions are curried, it is possible to give all three arguments to
+`substring` like the following:
+
+```js
+assert value substring(1)(3)("sheep") == "he"
+```
+
+However, having to surround each argument with parentheses is quite cumbersome
+and verbose. N provides syntactic sugar for passing multiple arguments to a
+function at once in sequence by separating each argument with a comma. This is
+similar to C-style function calling used by a few programming languages, so
+users of those languages should be familiar with this syntax.
+
+```js
+assert value substring(1, 3, "sheep") == "he"
+```
+
+#### More syntactic sugar with `()`
+
+If a function takes a `()`, you can call a function passing in the `()` by
+simply doing `functionName()` instead of `functionName(())`.
+
+### Immediately invoked function expressions
+
+In some cases, you may want to declare a temporary variable in an expression
+context. Immmediately invoked function expressions (IIFEs) can be used to
+include multiple statements and return a value.
+
+```js
+let deltaXSquared = [] -> float {
+	let deltaX = x1 - x2
+	return deltaX * deltaX
+}()
+
+// Alternative
+
+let deltaXSquared = () |> [] -> float {
+	let deltaX = x1 - x2
+	return deltaX * deltaX
+}
+```
+
+**NOTE**: Some implementations require parentheses around function expressions
+when used like this.
+
+This pattern is especially useful for creating a `cmd[()]` to export as the main
+command for an N program.
+
+```js
+import times
+
+let pub main = [] -> cmd[()] {
+	print("Wait a second...")
+	times.sleep(1000)!
+	print("Thanks.")
+}()
+```
+
+See [Procedures](./async.md) for more information on commands.

--- a/docs/features/functions.md
+++ b/docs/features/functions.md
@@ -59,7 +59,7 @@ curly brackets (`{` and `}`).
 (`:`) after the return type. You would expect the documentation to document
 this, but there's not that much information on it even for the people writing
 this, and it seems the implementations don't agree on it. There're also no tests
-specifying its behaviour and syntax.
+specifying its behavior and syntax.
 
 Functions are required to `return` a value with the proper type by the end of
 the function.

--- a/docs/features/functions.md
+++ b/docs/features/functions.md
@@ -42,7 +42,7 @@ called.
 Function expressions start with a list of arguments, separated by spaces and
 enclosed by square brackets. Each argument consists of a [definite
 pattern](./destructuring.md), which can just be the argument name, followed by a
-colon (`:`) then the type annotation of the argument. Note that unlike `let`
+colon (`:`) then the type annotation of the argument. Note that, unlike `let`
 statements, argument type annotations cannot be inferred and thus are required.
 In the example above, the function expression has two arguments: `a` and `b`,
 both floats.

--- a/docs/features/if_statements.md
+++ b/docs/features/if_statements.md
@@ -1,32 +1,85 @@
-# If Statements
+# `if` statements and expressions
+
+Like many programming languages, N has `if` and `if`/`else` statements and
+expressions for control flow.
+
+Its syntax is inspired by Rust, so no parentheses are required around the
+condition. <!-- However, for aesthetic reasons, omitting parentheses is
+discouraged and may be required in a future version of N. -->
+
+## `if` and `if`/`else` statements
+
+`if` statements can be used wherever other statements like the `let` statement
+are allowed; the `else` branch is not required.
 
 ```js
-// Simple if statement that will always be false
-
-if (1 /= 1) { // usually if (1 != 1) in other languages
-	print("This will never run")
-} else if (false) {
-	print("This will never run")
-} else {
-	print("This will always run")
-}
-
-// The conditional let will only run the block of code if the value can be assigned to the variable
-if let i = "This will always run" {
-	print(i)
-}
-
-let notNone:maybe[str] = yes("This will always run")
-
-if let <yes test> = notNone {
-	print(test) // test is not a maybe, it is a string
-}
-
-if let <yes test> = none {
-	print("This will never run")
+if divisor == 0 {
+	return err("Cannot divide by zero.")
 }
 ```
 
-## Notes:
-- There is no parenthesis in between `if` and `let` on a conditional let
-- Conditional lets can be used with [destructuring](./destructuring.md).
+The statements in the `if` and `else` branches must be enclosed by curly
+brackets (`{` and `}`); they are not optional. Multiple statements can be used
+inside the branches. You can also use `else if` without needing curly brackets
+around the second `if` statement.
+
+```js
+type divisionError =
+	| divisionByZero
+	| dividendNotDivisible
+
+let divideSafe = [dividend:int divisor:int] -> result[int, divisionError] {
+	if divisor == 0 {
+		return err(divisionByZero)
+	} else if dividend % divisor /= 0 {
+		return err(dividendNotDivisible)
+	} else {
+		let quotient = dividend / divisor
+		return ok(quotient)
+	}
+}
+```
+
+## `if`/`else` expressions
+
+N uses a similar syntax for `if`/`else` expressions for returning different
+values based on the condition. This is equivalent to the ternary operator found
+in a few programming languages such as C.
+
+While the syntax is similar, the `else` branch is required for expressions, and
+the curly brackets may only contain an expression. Statements cannot be used
+within `if`/`else` expressions.
+
+```js
+print(
+	"n is "
+		+ if n % 2 == 0 {
+			"even"
+		} else {
+			"odd"
+		}
+)
+```
+
+## `if let`
+
+Instead of an expression, `if` statements and expressions also support `if let`.
+`if let` is followed by a [conditional pattern](./destructuring.md) then an
+expression; if the resulting value matches the pattern, then the `if` branch is
+run with the extracted values from the pattern. Otherwise, the `else` branch is
+run, if present.
+
+**NOTE**: `if let` is a special syntax, not an expression, so you cannot put
+parentheses around `let ... = ...`.
+
+`if let` is especially useful for extracting values contained in an enum value.
+For example, the following example gets the first item from a list `names`, but
+if the list is empty, then the `else` branch returns `Doe` as a default value.
+
+```js
+let first = if <yes name> = names[0] {
+	name
+} else {
+	"Doe"
+}
+```

--- a/docs/features/if_statements.md
+++ b/docs/features/if_statements.md
@@ -64,10 +64,11 @@ print(
 ## `if let`
 
 Instead of an expression, `if` statements and expressions also support `if let`.
-`if let` is followed by a [conditional pattern](./destructuring.md) then an
-expression; if the resulting value matches the pattern, then the `if` branch is
-run with the extracted values from the pattern. Otherwise, the `else` branch is
-run, if present.
+`if let` is followed by a [conditional
+pattern](./destructuring.md#conditional-patterns) then an expression; if the
+resulting value matches the pattern, then the `if` branch is run with the
+extracted values from the pattern. Otherwise, the `else` branch is run, if
+present.
 
 **NOTE**: `if let` is a special syntax, not an expression, so you cannot put
 parentheses around `let ... = ...`.

--- a/docs/features/importing_n_files.md
+++ b/docs/features/importing_n_files.md
@@ -1,6 +1,6 @@
 # Importing .n files
 
-This will be `import.n`
+Imports are a great way of using other people's code and exploding files so they are less cumbersome. The `imp` keyword is used to import another file along with a path to the file:
 ```js
 // the pub modifier allows variables to be public
 
@@ -20,6 +20,9 @@ let importedThings = imp "./import.n" // This goes though the file so it will pr
 print(importedThings.test) // Prints out hello
 //print(importedthigns.test2) will cause an error because it is not public
 ```
+The `pub` modifier is used to export values to other files. This is why it can be applied to nearly every type or variable declaration, as by default, all values are private, to prevent malicous or accidential messing of code in other files.
+
+Though it may be useful, circular imports are outlawed in the current system as there is no good way of making it work properly in the system we have defined.	
 
 ## Notes:
 - `imp` returns a record-like object and so its type is as such, so it cannot be assigned to a record typed variable.

--- a/docs/features/importing_n_files.md
+++ b/docs/features/importing_n_files.md
@@ -20,7 +20,7 @@ let importedThings = imp "./import.n" // This goes though the file so it will pr
 print(importedThings.test) // Prints out hello
 //print(importedthigns.test2) will cause an error because it is not public
 ```
-The `pub` modifier is used to export values to other files. This is why it can be applied to nearly every type or variable declaration, as by default, all values are private, to prevent malicous or accidential messing of code in other files.
+The `pub` modifier is used to export values to other files. This is why it can be applied to nearly every type or variable declaration, as by default, all values are private, to prevent malicious or accidental messing of code in other files.
 
 Though it may be useful, circular imports are outlawed in the current system as there is no good way of making it work properly in the system we have defined.	
 

--- a/docs/features/internal_libraries.md
+++ b/docs/features/internal_libraries.md
@@ -1,8 +1,20 @@
 # Internal Libraries
 
-Internal Libraries are used to add complicated features from Python and JavaScrpt for users to use in N, you can import these using the `import` keyword. Here are the libraries you can import:
+Internal Libraries are used to add complicated features from Python and JavaScript for users to use in N, you can import these using the `import` keyword. Here are the libraries you can import.
 
-`FileIO`: This is used for file input and output:
+**Table of contents**
+
+1. [`FileIO`](#FileIO)
+2. [`json`](#json)
+3. [`request`](#request)
+4. [`SystemIO`](#SystemIO)
+5. [`times`](#times)
+6. [`websocket`](#websocket)
+7. [Notes](#Notes)
+
+## `FileIO`
+
+This is used for file input and output:
 ```js
 import FileIO
 ```
@@ -49,7 +61,9 @@ Requires the `FILE_ALLOW` environment variable to be set to `true`, takes in a p
 FileIO.getFiles("./")!
 ```
 
-`json`: This is used for dealing with `json` information:
+## `json`
+
+This is used for dealing with `json` information:
 ```js
 import json
 ```
@@ -81,7 +95,9 @@ This takes in a string and will return a `json.value` in an attempt to parse it,
 print(json.parseSafe("{ test: \"test\" }") |> default(json.string("invalid")))
 ```
 
-`request`: used for http related activities:
+## `request`
+
+Used for http related activities:
 ```js
 import request
 ```
@@ -144,7 +160,9 @@ request.createServer(
 )!
 ```
 
-`SystemIO`: Used for interacting with the console:
+## `SystemIO`
+
+Used for interacting with the console:
 ```js
 import SystemIO
 ```
@@ -161,7 +179,9 @@ Requires the `COMMAND_ALLOW` environment variable to be set to `true`, takes in 
 SystemIO.run("echo hello")!
 ```
 
-`times`: Used for stopping the program and getting the current time:
+## `times`
+
+Used for stopping the program and getting the current time:
 ```js
 import times
 ```
@@ -178,7 +198,9 @@ Returns the current epoch time
 times.getTime()!
 ```
 
-`websocket`: Used for websocket related activities
+## `websocket`
+
+Used for websocket related activities
 ```js
 import websocket
 ```

--- a/docs/features/internal_libraries.md
+++ b/docs/features/internal_libraries.md
@@ -264,6 +264,6 @@ let _ = websocket.createServer(
 ```
 
 ## Notes
-- All of these are written in python or js.
+- All of these are written in Python or JavaScript.
 - Later there may be a way to write your own, but this is unlikely.
 - The imported libraries are not records, but record-like.

--- a/docs/features/internal_libraries.md
+++ b/docs/features/internal_libraries.md
@@ -1,50 +1,247 @@
 # Internal Libraries
 
+Internal Libraries are used to add complicated features from Python and JavaScrpt for users to use in N, you can import these using the `import` keyword. Here are the libraries you can import:
+
+`FileIO`: This is used for file input and output:
 ```js
-import fek // import imports an internal library as a special record of the same name into the program
-// fek.paer("hi") deprecated, as the fek library was a test that was left in by accident
+import FileIO
+```
 
-import FileIO // Used for File input and output
-FileIO.write("test.txt", "test")! // This overwrites everything inside the test.txt file, it also creates a new file if it does not exist, returns a cmd
-FileIO.append("test.txt", "test")! // This adds to the data that already exists in text.txt, it also creates a new file if it does not exist, returns a cmd
-FileIO.read("test.txt")! |> default("") // This returns a maybe[str] in case the file does not exist, returns a cmd
+`FileIO.write: str -> str -> cmd[()]`:
+Takes in a path to a file and writes the data wanted into it, this does clear the file and will create it if it does not exist.
+```js
+FileIO.write("test.txt", "test")!
+```
 
-import json // JSON enum and related functions, mostly used for request
-let value:json.value = json.object(mapFrom([ // This is a map[str, json.value]
-	("test", json.string("test")) // There are json.string, json.array, json.number, and json.none
-]))
-print(json.stringify(value)) // Turns a json.value into a string
-// print(json.parse("{ test: \"test\" }")) // Turns a string into a json.value, deprecated as it is unsafe and can throw errors
-print(json.parse("{ test: \"test\" }") |> default(json.string("invalid"))) // Turns a string into a maybe[json.value]
+`FileIO.append: str -> str -> cmd[()]`:
+Takes in a path to a file and writes the data wanted into it, this does not clear the file and will create it if it does not exist.
+```js
+FileIO.append("test.txt", "test")!
+```
 
-import request // Used for http requests for websites
-request.get("github.com", mapfrom([("","")]))! // Takes in a url and a header and returns a {code: int, response: str, return: json.value}, returns a cmd
-request.post("github.com", mapFrom(["hello", "hello"]), mapfrom([("","")]))! // Takes in a url, content, and a header and returns a {code: int, response: str, text: str}, returns a cmd
+`FileIO.read: str -> cmd[maybe[str]]`:
+Takes in a path to a file and reads the data in it, returns it as a string if it does exist.
+```js
+FileIO.read("test.txt")! |> default("")
+```
 
-import SystemIO // Used for System input output with the console
-print("You said: " + SystemIO.imp("hello! ")!) // Prints the prompt then takes in the value after an enter is pressed and returns it. Returns a cmd
+`FileIO.writeBytes: str -> list[int] -> cmd[()]`:
+Takes in a path to a file and writes the data wanted into it, this does clear the file and will create it if it does not exist.
+```js
+FileIO.writeBytes("test.txt", [32, 33, 34, 35])!
+```
 
-import times // Used for pausing execution
-// times.sleep(1000)! // Takes in a time in milliseconds and pauses execution for that long, deprecated as there is a bug that will always occur with this
+`FileIO.appendBytes: str -> list[int] -> cmd[()]`:
+Takes in a path to a file and writes the data wanted into it, this does not clear the file and will create it if it does not exist.
+```js
+FileIO.appendBytes("test.txt", [32, 33, 34, 35])!
+```
 
-import websocket // Used for connecting to WebSockets
+`FileIO.readBytes: str -> cmd[maybe[list[int]]]`:
+Takes in a path to a file and reads the data in it, returns it as a list of bytes if it does exist.
+```js
+FileIO.readBytes("test.txt")! |> default([])
+```
+
+`FileIO.getFiles: str -> cmd[list[(bool, str)]]`:
+Requires the `FILE_ALLOW` environment variable to be set to `true`, takes in a path and returns all of the files/folders there, the `bool` in the output indicates whether it is a file or not.
+```js
+FileIO.getFiles("./")!
+```
+
+`json`: This is used for dealing with `json` information:
+```js
+import json
+```
+
+`json.value`: An enum that is the main way that `json` deals with info:
+```js
+type pub value = <object map[str, value]>
+               | <number float>
+               | <string str>
+               | <boolean bool>
+               | null
+```
+
+`json.stringify: json.value -> str`:
+This takes a json value and turns it into a string for ease of use.
+```js
+print(json.stringify(value))
+```
+
+`json.parse: str -> json.value`:
+This takes in a string and will return a `json.value` in an attempt to parse it, if it cannot parse it then it will return a `json.null`
+```js
+print(json.parse("{ test: \"test\" }"))
+```
+
+`json.parseSafe: str -> maybe[json.value]`:
+This takes in a string and will return a `json.value` in an attempt to parse it, if it cannot parse it then it will return `none`
+```js
+print(json.parseSafe("{ test: \"test\" }") |> default(json.string("invalid")))
+```
+
+`request`: used for http related activities:
+```js
+import request
+```
+
+`request.get: str -> map[str, str] -> cmd[{ code: int; response: str; return: json.value }:`:
+This takes in a url and a set of headers and makes a GET request to the url with those headers
+```js
+request.get("github.com", mapfrom([("","")]))!
+```
+
+`request.post: str -> map[str, str] -> map[str, str] -> cmd[{ code: int; response: str; text: str }`:
+This takes in a url, data to send, and headers and makes a POST request to the url with that data.
+```js
+request.post("github.com", mapFrom(["hello", "hello"]), mapfrom([("","")]))!
+```
+
+`request.delete: str -> map[str, str] -> cmd[{ code: int; response: str; return: json.value }:`:
+This takes in a url and a set of headers and makes a DELETE request to the url with those headers
+```js
+request.delete("github.com", mapfrom([("","")]))!
+```
+
+`request.head: str -> map[str, str] -> cmd[{ code: int; response: str; return: json.value }:`:
+This takes in a url and a set of headers and makes a HEAD request to the url with those headers
+```js
+request.head("github.com", mapfrom([("","")]))!
+```
+
+`request.options: str -> map[str, str] -> cmd[{ code: int; response: str; return: json.value }:`:
+This takes in a url and a set of headers and makes a OPTIONS request to the url with those headers
+```js
+request.options("github.com", mapfrom([("","")]))!
+```
+
+`request.patch: str -> map[str, str] -> map[str, str] -> cmd[{ code: int; response: str; text: str }`:
+This takes in a url, data to send, and headers and makes a PATCH request to the url with that data.
+```js
+request.patch("github.com", mapFrom(["hello", "hello"]), mapfrom([("","")]))!
+```
+
+`request.put: str -> map[str, str] -> map[str, str] -> cmd[{ code: int; response: str; text: str }`:
+This takes in a url, data to send, and headers and makes a PUT request to the url with that data.
+```js
+request.put("github.com", mapFrom(["hello", "hello"]), mapfrom([("","")]))!
+```
+
+`request.createServer: int -> ( str -> str -> json.value -> cmd[{ responseCode: int; data: list[int]; headers: map[str, str]; mimetype: str }] ) -> cmd[()]`:
+This takes in a port to open to and a function which takes in a path, request type, and additional data and returns a response code, the data in bytes, headers, and the MIME type for the data given and opens a server on `http://localhost:<PORTNUMBER>`
+```js
+request.createServer(
+  3000,
+  [path:str requestType:str additionalData:str] -> cmd[{ responseCode: int; data: list[int]; headers: map[str, str]; mimetype: str }] {
+    return {
+      responseCode: 200
+      data: [32, 33, 34, 35]
+      headers: mapFrom([])
+      mimetype: "text/plain"
+    }
+  }
+)!
+```
+
+`SystemIO`: Used for interacting with the console:
+```js
+import SystemIO
+```
+
+`SystemIO.inp: str -> cmd[str]`:
+Takes in a string and prints it out and awaits user input, once it is inputted it will give back the input
+```js
+print("You said: " + SystemIO.inp("hello! ")!)
+```
+
+`SystemIO.run: str -> cmd[bool]`:
+Requires the `COMMAND_ALLOW` environment variable to be set to `true`, takes in a string and runs the command in the terminal, returns `true` if it was successful
+```js
+SystemIO.run("echo hello")!
+```
+
+`times`: Used for stopping the program and getting the current time:
+```js
+import times
+```
+
+`times.sleep: int -> cmd[()]`:
+Takes in an integer and stops the thread it is in for that many milliseconds
+```js
+times.sleep(1000)!
+```
+
+`times.getTime: () -> cmd[float]`:
+Returns the current epoch time
+```js
+times.getTime()!
+```
+
+`websocket`: Used for websocket related activities
+```js
+import websocket
+```
+
+`websocket.send: str -> cmd[result[(), int]]`:
+This is a type used for sending data in a websocket, if it does not have an error it will return an `ok(())` otherwise it will return an `err` with the error code it got.
+```js
+alias send = str -> cmd[()]
+```
+
+`websocket.close: () -> cmd[()]`:
+Currently unused.
+
+`websocket.user: { send: str -> cmd[()]; disconnect: () -> cmd[()]; ip: (int, int, int, int); uuid: str }`:
+Used as an individual user when hosting a websocket server.
+```js
+alias user = {
+  send: str -> cmd[()]
+  disconnect: () -> cmd[()]
+  ip: (int, int, int, int)
+  uuid: str
+}
+```
+
+`websocket.connect: { onOpen: websocket.send -> cmd[bool]; onMessage: websocket.send -> cmd[bool] } -> str -> cmd[maybe[str]]`:
+Connects to a websocket, `onOpen` and `onMessage` run in parallel and if either return `true` it will exit out of both, the `str` is an error message that my occur when connecting.
+```js
 let websocketTest = websocket.connect({
   onOpen: [send: websocket.send] -> cmd[bool] {
     print("Open!")
     let _ = send("hi")!
     return false
-  },
+  }
   onMessage: [send: websocket.send message: str] -> cmd[bool] {
     print(message)
     let _ = send("hello")!
     return message == "hello"
   }
-}, "wss://echo.websocket.org")! // This takes in a record of an onOpen function, which runs when the websocket is opened, and an onMessage function, which runs when there is a message, returns a cmd
-// Both functions return a boolean for whether to stop (true) or continue (false)
-// websocket.send is a function that is one of the arguments in both of the functions that is a function to send data to the WebSocket that it is connected to
+}, "wss://echo.websocket.org")!
+```
+
+`websocket.createServer: int -> { onConnect: websocket.user -> str -> cmd[bool]; onMessage: websocket.user -> str -> cmd[bool]; onDisconnect: websocket.user -> { code: int; reson: str } -> cmd[bool] }`:
+Opens a websocket server on `ws://localhost:<PORTNUMBER>`. Runs `onConnect` when a user connects, `onMessage` runs when a user sends a message, and `onDisconnect` will run when a user disconnects, if either of these return `true` then the websocket server will close.
+```js
+let _ = websocket.createServer(
+  {
+    onConnect: [user:websocket.user path:str] -> cmd[bool] {
+      print(user)
+      let _ = user.send("hello")!
+      return false
+    }
+    onMessage: [user:websocket.user message:str] -> cmd[bool] {
+      print(message)
+      let _ = user.send(message)!
+      return false
+    }
+    onDisconnect: [user:websocket.user exitData:maybe[{ code: int; reason:str }]] -> cmd[bool] { return false }
+  },
+  3000
+)!
 ```
 
 ## Notes
-- All of these are written in python.
+- All of these are written in python or js.
 - Later there may be a way to write your own, but this is unlikely.
 - The imported libraries are not records, but record-like.

--- a/docs/features/literals.md
+++ b/docs/features/literals.md
@@ -5,7 +5,7 @@ Literals are the raw values like `1` or `"a"` that are the main basis for values
 ## Number Literals
 
 ### Decimal Literals
-This is the plain and simple way of writing an int, it is a base ten number such as `10`:
+This is the plain and simple way of writing an int, it is a base-ten number such as `10`:
 ```js
 let val = 32
 

--- a/docs/features/literals.md
+++ b/docs/features/literals.md
@@ -1,0 +1,140 @@
+# Literals
+
+Literals are the raw values like `1` or `"a"` that are the main basis for values in N along with variables, this will go though all literals currently in N.
+
+## Number Literals
+
+### Decimal Literals
+This is the plain and simple way of writing an int, it is a base ten number such as `10`:
+```js
+let val = 32
+
+print(val) // prints out 32
+```
+
+### Float Literals
+This is the same as the decimal literal, but it has a decimal point so it evals to a float:
+```js
+let val = 32.5
+
+print(val) // prints out 32.5
+```
+
+### Hex Literals
+This allows you to write in hex and is prefaced by a `0x`, this ends up evaluating to an int:
+```js
+let val = 0xff
+
+print(val) // prints out 255
+```
+
+### Octal Literals
+This allows you to write in octal and is prefaced by a `0o`, this ends up evaluating to an int:
+```js
+let val = 0o21
+
+print(val) // prints out 17
+```
+
+### Binary Literals
+This allows you to write in binary and is prefaced by a `0b`, this ends up evaluating to an int:
+```js
+let val = 0b1011
+
+print(val) // prints out 11
+```
+
+## Boolean Literals
+This allows you to write raw `true` or `false` values:
+```js
+let val = false
+
+print(val) // prints out false
+```
+
+## List Literals
+This is the main way to write out lists:
+```js
+let val = [1, 2, 3]
+
+print(val) // prints out [1, 2, 3]
+```
+List literals can also use the `..` operator to combine lists into it:
+```js
+let val = [..[1, 2], 3]
+
+print(val) // prints out [1, 2, 3]
+```
+
+## Tuple Literals
+This is the main way to write out tuples:
+```js
+let val = (1, "2", false)
+
+print(val) // prints out (1, "2", false)
+```
+
+## Record Literals
+This is the main way to write out records:
+```js
+let val = {
+	value1: 1
+	value2: "2"
+}
+
+print(val) // prints out { value1: 1; value2: "2" }
+```
+Records literals can also used the `..` operator to combine or override fields:
+```js
+let val = {
+	..{ value1: 1; value2: "2" }
+	..{ value2: "3"; value3: false}
+}
+
+print(val) // prints out { value1: 1; value2: "3"; value3: false }
+```
+
+## Char Literals
+
+### Raw Char Literals
+This is the main way of turning a unicode character into a char:
+```js
+let val = \{a}
+
+print(val) // prints out a
+```
+
+### Escape Code Literals
+This is the main way of using special characters such as `\n`:
+```js
+let val = \n
+
+print(val) // prints out a newline
+```
+The currently supported escape codes are `\n`, `\t`, `\r`, `\v`, `\0`, `\f`, and `\b`.
+
+### Unicode Escape Code Literals
+This is the main way of getting a unicode character from its hex index:
+```js
+let val = \u{ff}
+
+print(val) // prints out ÿ
+```
+
+## String Literals
+This is the main way to write out raw strings for use in a program:
+```js
+let val = "hello!"
+
+print(val) // prints out hello!
+```
+String literals can also use escape codes such as the Escape Code Literals and the Unicode Escape Code Literals. In addition to those it can also use the `\"` escape code to allow for "s in the string:
+```js
+let val = "hello!\n (\"how are \u{ff}ou\")"
+
+print(val) // prints out:
+/*
+hello!
+ ("how are ÿou")
+*/
+```

--- a/docs/features/literals.md
+++ b/docs/features/literals.md
@@ -114,7 +114,7 @@ print(val) // prints out a newline
 The currently supported escape codes are `\n`, `\t`, `\r`, `\v`, `\0`, `\f`, and `\b`.
 
 ### Unicode Escape Code Literals
-This is the main way of getting a unicode character from its hex index:
+This is the main way of getting a Unicode character from its hex index:
 ```js
 let val = \u{ff}
 

--- a/docs/features/literals.md
+++ b/docs/features/literals.md
@@ -1,6 +1,6 @@
 # Literals
 
-Literals are the raw values like `1` or `"a"` that are the main basis for values in N along with variables, this will go though all literals currently in N.
+Literals are the raw values like `1` or `"a"` that are the main basis for values in N along with variables, this will go through all literals currently in N.
 
 ## Number Literals
 

--- a/docs/features/literals.md
+++ b/docs/features/literals.md
@@ -97,7 +97,7 @@ print(val) // prints out { value1: 1; value2: "3"; value3: false }
 ## Char Literals
 
 ### Raw Char Literals
-This is the main way of turning a unicode character into a char:
+This is the main way of turning a Unicode character into a char:
 ```js
 let val = \{a}
 

--- a/docs/features/match.md
+++ b/docs/features/match.md
@@ -1,6 +1,6 @@
 # Match
 
-Match expressions are a faster and more effective way of checking values then repitions of if else statements, as instead of checking each one until the condition matches, it checks immediatly using a dictionary internally. Here is an example of a match statement:
+Match expressions are a faster and more effective way of checking values than reeditions of if-else statements, as instead of checking each one until the condition matches, it checks immediately using a dictionary internally. Here is an example of a match statement:
 ```js
 print(match ("Hello!") {
 	"Hello!" -> "hi"

--- a/docs/features/match.md
+++ b/docs/features/match.md
@@ -1,0 +1,26 @@
+# Match
+
+Match expressions are a faster and more effective way of checking values then repitions of if else statements, as instead of checking each one until the condition matches, it checks immediatly using a dictionary internally. Here is an example of a match statement:
+```js
+print(match ("Hello!") {
+	"Hello!" -> "hi"
+	"How are you?" -> "I am good"
+	_ -> "I do not understand"
+})
+```
+This prints out `hi`. Match statements take in a value and it will take in a set of inputs and outputs, along with a default or `_` option, which it will fall back upon if it cannot find a matching input for the value given in. Here is an example:
+```js
+print(match ("e") {
+	"Hello!" -> "hi"
+	"How are you?" -> "I am good"
+	_ -> "I do not understand"
+})
+```
+This will print out `I do not understand`.
+
+## Notes:
+- You cannot have two default options
+- You can have expressions as an input
+- If you have two of the same input it will choose the one later
+- All inputs must be of the same type
+- All outputts must be of the same type

--- a/docs/features/native_functions.md
+++ b/docs/features/native_functions.md
@@ -200,7 +200,7 @@ assert value subsection(3, 2, [1, 2, 3]) == []
 Applies the given function to each item in the given list. If the function
 returns `none`, the item will not be included in the list; otherwise, the
 contained value in the `maybe` value will be included in the new list. Returns a
-new list containing the resulting `yes` contained values given by the function.
+new list containing the resulting `yes`-contained values given by the function.
 
 `filterMap` is intentionally generalised because `filter` and `map` can be
 easily defined in terms of `filterMap`.

--- a/docs/features/native_functions.md
+++ b/docs/features/native_functions.md
@@ -248,7 +248,7 @@ let map = mapFrom([("a", 1), ("b", 2)])
 assert type map : map[str, int]
 ```
 
-**NOTE**: Maps allow functions and commands as keys, but the behaviour of these
+**NOTE**: Maps allow functions and commands as keys, but the behavior of these
 maps is undefined.
 
 ### `entries` : `[k, v] map[k, v] -> list[(k, v)]`

--- a/docs/features/native_functions.md
+++ b/docs/features/native_functions.md
@@ -145,7 +145,7 @@ nbuilding/N-lang#245.
 
 ### `len` : `[t] t -> int`
 
-Gets the length of the given value. The behaviour of `len` depends on the type
+Gets the length of the given value. The behavior of `len` depends on the type
 of value given; if the argument is a string or list, then it'll return its
 length (for strings, this is in Unicode characters, not code points or
 graphemes). Otherwise, it'll return zero.

--- a/docs/features/native_functions.md
+++ b/docs/features/native_functions.md
@@ -26,6 +26,9 @@ assert value intInBase10(10) = "10"
 **NOTE**: To convert a float to a string, use the `stringify` function from the
 `json` built-in module.
 
+**NOTE**: To parse a string as an integer or float, use the `parse` or
+`parseSafe` function from the `json` module.
+
 ### `toFloat` : `int -> float`
 
 Converts an integer to a float. Inverse of `round`, `floor`, and `ceil`.
@@ -152,25 +155,6 @@ assert value len("abc") = 3
 assert value len(100) = 0
 ```
 
-### `range` : `int -> int -> int -> list[int]`
-
-Returns a list of integers within the specified range. This takes a starting
-value (inclusive), an end value (exclusive), and a step value. This is based on
-[Python's `range`
-constructor](https://docs.python.org/3/library/stdtypes.html#typesseq-range), so
-it supports negative step values.
-
-```ts
-assert value range(0, 3, 1) = [0, 1, 2]
-assert value range(0, 10, 1) = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-assert value range(1, 11, 1) = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-assert value range(0, 30, 5) = [0, 5, 10, 15, 20, 25]
-assert value range(0, 10, 3) = [0, 3, 6, 9]
-assert value range(0, -10, -1) = [0, -1, -2, -3, -4, -5, -6, -7, -8, -9]
-assert value range(0, 0, 1) = []
-assert value range(1, 0, 1) = []
-```
-
 ### `itemAt` : `[t] int -> list[t] -> maybe[t]`
 
 Gets the item of a list by index. Does not support negative indices.
@@ -182,6 +166,9 @@ assert value itemAt(-1, [1, 2, 3]) = none
 
 **NOTE**: N now has a special list item access syntax that should be used
 instead: `list[index]`.
+
+**NOTE**: The representation of lists in memory is implementation-defined, so
+item access may be O(n) in the worst case.
 
 ### `append` : `[t] t -> list[t] -> list[t]`
 
@@ -215,11 +202,40 @@ returns `none`, the item will not be included in the list; otherwise, the
 contained value in the `maybe` value will be included in the new list. Returns a
 new list containing the resulting `yes` contained values given by the function.
 
+`filterMap` is intentionally generalised because `filter` and `map` can be
+easily defined in terms of `filterMap`.
+
 ```ts
 assert value filterMap([value:int] -> maybe[int] {
 	return yes(value * value + 1)
 }, [0, 1, 2, 3, 4]) = [1, 2, 5, 10, 17]
 ```
+
+### `range` : `int -> int -> int -> list[int]`
+
+Returns a list of integers within the specified range. This takes a starting
+value (inclusive), an end value (exclusive), and a step value. This is based on
+[Python's `range`
+constructor](https://docs.python.org/3/library/stdtypes.html#typesseq-range), so
+it supports negative step values.
+
+`range` is intended to be used with `for` loops to loop over a range of
+integers.
+
+```ts
+assert value range(0, 3, 1) = [0, 1, 2]
+assert value range(0, 10, 1) = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+assert value range(1, 11, 1) = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+assert value range(0, 30, 5) = [0, 5, 10, 15, 20, 25]
+assert value range(0, 10, 3) = [0, 3, 6, 9]
+assert value range(0, -10, -1) = [0, -1, -2, -3, -4, -5, -6, -7, -8, -9]
+assert value range(0, 0, 1) = []
+assert value range(1, 0, 1) = []
+```
+
+**NOTE**: The representation of lists in memory is implementation-defined, so an
+implementation may attempt to store the entire list in memory. This may be
+costly for performance when iterating over a large range.
 
 ## Maps
 
@@ -235,18 +251,6 @@ assert type map : map[str, int]
 **NOTE**: Maps allow functions and commands as keys, but the behaviour of these
 maps is undefined.
 
-### `getValue` : `[k, v] k -> map[k, v] -> maybe[v]`
-
-Gets a value from the given map by the given key.
-
-```ts
-assert value getValue("b", map) = yes(2)
-assert value getValue("c", map) = none
-```
-
-**NOTE**: N now has a special list item access syntax that should be used
-instead: `map[key]`.
-
 ### `entries` : `[k, v] map[k, v] -> list[(k, v)]`
 
 Returns a list of key-value pairs from the map. Inverse of `mapFrom`.
@@ -256,6 +260,21 @@ assert value entries(map) = [("a", 1), ("b", 2)]
 ```
 
 **NOTE**: The order of the key-value pairs should be preserved.
+
+### `getValue` : `[k, v] k -> map[k, v] -> maybe[v]`
+
+Gets a value from the given map by the given key.
+
+```ts
+assert value getValue("b", map) = yes(2)
+assert value getValue("c", map) = none
+```
+
+**NOTE**: N now has a special map value access syntax that should be used
+instead: `map[key]`.
+
+**NOTE**: The value access algorithm is implementation-defined and may be O(n)
+in the worst case.
 
 ## `maybe` values
 

--- a/docs/features/native_functions.md
+++ b/docs/features/native_functions.md
@@ -202,7 +202,7 @@ returns `none`, the item will not be included in the list; otherwise, the
 contained value in the `maybe` value will be included in the new list. Returns a
 new list containing the resulting `yes`-contained values given by the function.
 
-`filterMap` is intentionally generalised because `filter` and `map` can be
+`filterMap` is intentionally generalized because `filter` and `map` can be
 easily defined in terms of `filterMap`.
 
 ```ts

--- a/docs/features/native_functions.md
+++ b/docs/features/native_functions.md
@@ -1,31 +1,426 @@
-# Native Functions
+# Built-in functions
 
-```js
-intInBase10(10) // Takes in an int and returns the string version.
-round(10.5) // Rounds a float to the nearest value, returns an int.
-floor(10.5) // Rounds down a float to the nearest value, returns an int.
-ceil(10.4) // Rounds up a float to the nearest value, returns an int.
-charCode(\{a}) // Returns the unicode code for a character.
-intCode(32) // Returns the character associated for an int.
-charAt(1, "abc") // Returns the character at an index of a string, takes in an int and a string and returns a maybe char.
-substring(0, 2, "abc") // Takes in a start, an end, and a string and returns a string.
-len("abc") // Takes in any value and returns the length of it. For lists and tuples it gets the amount of items otherwise it is string representation.
-split(\{b}, "abc") // Splits a string based on a character as many times as possible and returns a list[str].
-strip(" abc ") // Returns a string with removed whitespace from the end.
-range(0, 10, 1) // Returns a list of ints that takes in a start, and end, and a step value.
-//type(10) // Takes in any object and returns the type of it as a string. Deprecated until new name is added.
-print("test") // Takes in any type and prints it out in a formatted way. It also returns the value printed out.
-itemAt(1, [1, 2, 3]) // Takes in an int and a list of any type and returns a maybe of the item that might be there.
-append(4, [1, 2, 3]) // Returns a list with the item added to the end, this is not a void function.
-filterMap([value:int] -> maybe[int] {
-	return yes(value + 1)
-}, [0, 1, 2]) // This takes in a function and a list and applies to function to all items in the list, this also returns a copy of the list.
-default("test1", yes("test")) // This will turn a maybe into a regular type but if the value is none then it will use the default value instead
-then(func, someCmdFunction()) // Runs the function after the cmd is done
-mapFrom([("a", 1), ("b", 2)]) // Takes in a list of tuples and returns a map
-getValue("b", map) // Takes in a key and a map and returns a maybe
-entries(map) // Returns all of the values in the map
+N provides many built-in functions that are available to use globally without
+needing to import anything.
+
+**Contents**
+
+- [Basics](#basics)
+- [Lists](#lists)
+- [Maps](#maps)
+- [`maybe` values](#maybe-values)
+- [Commands](#commands)
+- [Printing for debugging](#printing-for-debugging)
+- [Runtime unit tests](#runtime-unit-tests)
+
+## Basics
+
+### `intInBase10` : `int -> str`
+
+Converts an integer to a string.
+
+```ts
+assert value intInBase10(10) = "10"
 ```
 
-## Notes
-- All of these are meant to be used with the [pipe operator](./currying.md).
+**NOTE**: To convert a float to a string, use the `stringify` function from the
+`json` built-in module.
+
+### `toFloat` : `int -> float`
+
+Converts an integer to a float. Inverse of `round`, `floor`, and `ceil`.
+
+```ts
+assert value toFloat(3) == 3.0
+```
+
+### `round` : `float -> int`
+
+Converts a float to an integer. Non-integers are rounded to the nearest integer;
+if the fractional part is 0.5, then it is rounded up. Inverse of `toFloat`.
+
+```ts
+assert value round(10.5) = 11
+assert value round(-10.5) = -10
+```
+
+**NOTE**: The behaviour for `round`, `floor`, and `ceil` when given an infinity
+or NaN is undefined. See nbuilding/N-lang#243.
+
+### `floor` : `float -> int`
+
+Converts a float to an integer, rounding down. Inverse of `toFloat`.
+
+```ts
+assert value floor(10.5) = 10
+assert value floor(-10.5) = -11
+```
+
+### `ceil` : `float -> int`
+
+Converts a float to an integer, rounding up. Inverse of `toFloat`.
+
+```ts
+assert value ceil(10.5) = 11
+assert value ceil(10.4) = 11
+assert value ceil(-10.5) = -10
+```
+
+### `charCode` : `char -> int`
+
+Gets the Unicode code point value for the given character. Inverse of `intCode`.
+
+```ts
+assert value charCode(\{a}) = 97
+assert value charCode(\{🕴}) = 0x1f574
+```
+
+### `intCode` : `int -> char`
+
+Converts the given Unicode code point to the corresponding character. Invalid
+code points are converted to � (U+FFFD, REPLACEMENT CHARACTER). Inverse of
+`charCode`.
+
+```ts
+assert value intCode(32) = \{ }
+assert value intCode(-1) = \u{FFFD}
+```
+
+### `charAt` : `int -> str -> maybe[char]`
+
+Gets the character (not grapheme or code point) at the given index. Since
+strings are probably not stored in UTF-32, this is probably O(n), but this is
+implementation defined. Negative indices aren't supported.
+
+```ts
+assert value charAt(1, "abc") = yes(\{b})
+assert value charAt(-1, "abc") = none
+```
+
+**NOTE**: N now has a special character access syntax that should be used
+instead: `string[index]`.
+
+### `substring` : `int -> int -> str -> str`
+
+Gets a portion of a string given a start index (inclusive) then the end index
+(exclusive). The indices work as they do in Python, so they support negative
+indices; however, if the start index is after the end index, then `substring`
+returns an emtpy string.
+
+```ts
+assert value substring(0, 2, "abc") = "ab"
+assert value substring(-3, -1, "apple sauce") = "uc"
+assert value substring(0, -1, "banana jam") = "banana ja"
+assert value substring(0, 100, "hi") = "hi"
+assert value substring(2, 100, "hi") = ""
+assert value substring(5, 3, "hello world") = ""
+```
+
+### `split` : `char -> str -> list[str]`
+
+Splits the given string by a character. Returns an empty array for an empty
+string.
+
+```ts
+assert value split(\{b}, "abc") = ["a", "c"]
+assert value split(\{b}, "") = []
+assert value split(\{b}, "apple") = ["apple"]
+```
+
+### `strip` : `str -> str`
+
+Removes whitespace characters.
+
+```ts
+assert value strip(" abc ") = "abc"
+```
+
+**NOTE**: The characters removed by `strip` are implementation defined. See
+nbuilding/N-lang#245.
+
+## Lists
+
+### `len` : `[t] t -> int`
+
+Gets the length of the given value. The behaviour of `len` depends on the type
+of value given; if the argument is a string or list, then it'll return its
+length (for strings, this is in Unicode characters, not code points or
+graphemes). Otherwise, it'll return zero.
+
+```ts
+assert value len("abc") = 3
+assert value len(100) = 0
+```
+
+### `range` : `int -> int -> int -> list[int]`
+
+Returns a list of integers within the specified range. This takes a starting
+value (inclusive), an end value (exclusive), and a step value. This is based on
+[Python's `range`
+constructor](https://docs.python.org/3/library/stdtypes.html#typesseq-range), so
+it supports negative step values.
+
+```ts
+assert value range(0, 3, 1) = [0, 1, 2]
+assert value range(0, 10, 1) = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+assert value range(1, 11, 1) = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+assert value range(0, 30, 5) = [0, 5, 10, 15, 20, 25]
+assert value range(0, 10, 3) = [0, 3, 6, 9]
+assert value range(0, -10, -1) = [0, -1, -2, -3, -4, -5, -6, -7, -8, -9]
+assert value range(0, 0, 1) = []
+assert value range(1, 0, 1) = []
+```
+
+### `itemAt` : `[t] int -> list[t] -> maybe[t]`
+
+Gets the item of a list by index. Does not support negative indices.
+
+```ts
+assert value itemAt(1, [1, 2, 3]) = yes(2)
+assert value itemAt(-1, [1, 2, 3]) = none
+```
+
+**NOTE**: N now has a special list item access syntax that should be used
+instead: `list[index]`.
+
+### `append` : `[t] t -> list[t] -> list[t]`
+
+Returns a new list with the given item added to the end of the given list.
+
+```ts
+let list = [1, 2, 3]
+assert value append(4, list) = [1, 2, 3, 4]
+assert value list = [1, 2, 3]
+```
+
+**NOTE**: `append` does not mutate the list.
+
+### `subsection` : `[t] int -> int -> list[t] -> list[t]`
+
+Returns a list containing a portion of the items in the given list; analogous to
+`substring` but for lists.
+
+```ts
+assert value subsection(2, 4, [0, 1, 2, 3, 4, 5]) == [2, 3]
+assert value subsection(4, 1000, [0, 1, 2, 3, 4, 5]) == [4, 5]
+assert value subsection(-3, -5, [1, 2, 3]) == []
+assert value subsection(-3, 1, [1, 2, 3]) == [1]
+assert value subsection(3, 2, [1, 2, 3]) == []
+```
+
+### `filterMap` : `[a, b] (a -> maybe[b]) -> list[a] -> list[b]`
+
+Applies the given function to each item in the given list. If the function
+returns `none`, the item will not be included in the list; otherwise, the
+contained value in the `maybe` value will be included in the new list. Returns a
+new list containing the resulting `yes` contained values given by the function.
+
+```ts
+assert value filterMap([value:int] -> maybe[int] {
+	return yes(value * value + 1)
+}, [0, 1, 2, 3, 4]) = [1, 2, 5, 10, 17]
+```
+
+## Maps
+
+### `mapFrom` : `[k, v] list[(k, v)] -> map[k, v]`
+
+Creates a map from the given list of key-value pairs. Inverse of `entries`.
+
+```ts
+let map = mapFrom([("a", 1), ("b", 2)])
+assert type map : map[str, int]
+```
+
+**NOTE**: Maps allow functions and commands as keys, but the behaviour of these
+maps is undefined.
+
+### `getValue` : `[k, v] k -> map[k, v] -> maybe[v]`
+
+Gets a value from the given map by the given key.
+
+```ts
+assert value getValue("b", map) = yes(2)
+assert value getValue("c", map) = none
+```
+
+**NOTE**: N now has a special list item access syntax that should be used
+instead: `map[key]`.
+
+### `entries` : `[k, v] map[k, v] -> list[(k, v)]`
+
+Returns a list of key-value pairs from the map. Inverse of `mapFrom`.
+
+```ts
+assert value entries(map) = [("a", 1), ("b", 2)]
+```
+
+**NOTE**: The order of the key-value pairs should be preserved.
+
+## `maybe` values
+
+### `default` : `[t] t -> maybe[t] -> t`
+
+Given a default value and a `maybe` value, returns the default value if the
+`maybe` value is `none`; otherwise, it returns the value contained in the
+`maybe` value.
+
+```ts
+assert value default("test1", yes("test")) = "test"
+assert value default("test1", none) = "test1"
+```
+
+This is equivalent to:
+
+```ts
+let default = [[t] defaultValue:t maybe:maybe[t]] -> t {
+	if let <yes value> = maybe {
+		return value
+	} else {
+		return defaultValue
+	}
+}
+```
+
+## Commands
+
+### `then` : `[a, b] (a -> cmd[b]) -> cmd[a] -> cmd[b]`
+
+Returns a new command that first executes the given command, then runs the given
+function given the result from the given command, then executes the resulting
+command from that function.
+
+```ts
+import FileIO
+assert type then([text: maybe[str]] -> cmd[()] {
+	assert value len(text |> default("")) > 0
+}, FileIO.read("./README.md")) : cmd[()]
+```
+
+This is equivalent to:
+
+```ts
+let then = [[a, b] function:(a -> cmd[b]) command:cmd[a]] -> cmd[b] {
+	return function(command!)
+}
+```
+
+### `parallel` : `[t] cmd[t] -> cmd[cmd[t]]`
+
+Returns a new command that executes the given command in parallel. The result of
+this new command is another command that resolves when the given command
+finishes executing.
+
+You can use the resulting command of the command returned by `parallel` to wait
+for the command running in parallel to finish.
+
+```ts
+let parallelCmd = () |> ([] -> cmd[()] {
+	let _ = parallel(() |> ([] -> cmd[()] {
+		assert value true
+	}))!
+})
+```
+
+**NOTE**: The program exits when the main command finishes, so commands running
+in parallel will be stopped.
+
+## Printing for debugging
+
+### `printWithEnd` : `[t] str -> t -> t`
+
+Prints the given value to stdout followed by the specified string and flushes,
+then returns the value. Non-string values are pretty-printed in an
+implementation-defined manner.
+
+```ts
+let printed = 3.14
+	|> printWithEnd(" ")
+assert value printed == 3.14
+```
+
+**NOTE**: This function is impure, but it is not a procedure for convenience.
+Thus, this should only be used for development and debugging purposes, not for
+actual output to stdout.
+
+### `print` : `[t] t -> t`
+
+Equivalent to `printWithEnd("\n")` and thus shares its caveats.
+
+```ts
+assert value print("test") = "test"
+```
+
+## Runtime unit tests
+
+### `intoModule` : `[m] m -> maybe[module]`
+
+Attempts to convert the given type to a `module` value. Imports from `imp` will
+be successfully converted to a `module`; `intoModule` will return `none` for all
+other values.
+
+See `getUnitTestResults` below for an example.
+
+### `getUnitTestResults` : `module -> list[{ hasPassed: bool; fileLine: int; unitTestType: str; possibleTypes: maybe[(str, str)] }]`
+
+Gets a list of assertion results from the given `module` value. Assertion
+results are a record with fields that depend on the type of assertion used in
+the module.
+
+Results from both `assert type` and `assert value` will include a `hasPassed`
+field, a boolean that represents whether the assertion passed.
+
+`assert type` results also have the following fields:
+
+- `fileLine`, which is always `0`
+- `unitTestType`, which is always the string `"type"`
+- `possibleTypes`, which is a tuple containing implementation-defined strings
+  (meant to be displayed to the user) wrapped in `yes`.
+
+`assert value` results have the following fields:
+
+- `fileLine`, an integer representing the line the assertion was on
+- `unitTestType`, which is always the string `"value"`
+- `possibleTypes`, which is always `none`
+
+```ts
+if let <yes module> = intoModule(imp "./imports/unit-test.n") {
+	let results = getUnitTestResults(module)
+
+	assert value len(results) == 4
+
+	assert value (results |> itemAt(0)) == yes({
+		hasPassed: true
+		fileLine: 3
+		unitTestType: "value"
+		possibleTypes: none
+	})
+
+	assert value (results |> itemAt(1)) == yes({
+		hasPassed: false
+		fileLine: 5
+		unitTestType: "value"
+		possibleTypes: none
+	})
+
+	for (result in (results |> subsection(2, 4))) {
+		assert value result.hasPassed
+		assert value result.unitTestType == "type"
+		assert value if let <yes _> = result.possibleTypes { true } else { false }
+	}
+
+	assert value (results |> itemAt(2) |> default({
+		hasPassed: true
+		fileLine: 0
+		unitTestType: "value"
+		possibleTypes: none
+	})).fileLine == 7
+
+	assert value (results |> itemAt(3) |> default({
+		hasPassed: true
+		fileLine: 0
+		unitTestType: "value"
+		possibleTypes: none
+	})).fileLine == 9
+}
+```

--- a/docs/features/native_functions.md
+++ b/docs/features/native_functions.md
@@ -47,7 +47,7 @@ assert value round(10.5) = 11
 assert value round(-10.5) = -10
 ```
 
-**NOTE**: The behaviour for `round`, `floor`, and `ceil` when given an infinity
+**NOTE**: The behavior for `round`, `floor`, and `ceil` when given an infinity
 or NaN is undefined. See nbuilding/N-lang#243.
 
 ### `floor` : `float -> int`

--- a/docs/features/native_functions.md
+++ b/docs/features/native_functions.md
@@ -93,7 +93,7 @@ assert value intCode(-1) = \u{FFFD}
 
 Gets the character (not grapheme or code point) at the given index. Since
 strings are probably not stored in UTF-32, this is probably O(n), but this is
-implementation defined. Negative indices aren't supported.
+implementation-defined. Negative indices aren't supported.
 
 ```ts
 assert value charAt(1, "abc") = yes(\{b})

--- a/docs/features/native_functions.md
+++ b/docs/features/native_functions.md
@@ -108,7 +108,7 @@ instead: `string[index]`.
 Gets a portion of a string given a start index (inclusive) then the end index
 (exclusive). The indices work as they do in Python, so they support negative
 indices; however, if the start index is after the end index, then `substring`
-returns an emtpy string.
+returns an empty string.
 
 ```ts
 assert value substring(0, 2, "abc") = "ab"

--- a/docs/features/native_functions.md
+++ b/docs/features/native_functions.md
@@ -138,7 +138,7 @@ Removes whitespace characters.
 assert value strip(" abc ") = "abc"
 ```
 
-**NOTE**: The characters removed by `strip` are implementation defined. See
+**NOTE**: The characters removed by `strip` are implementation-defined. See
 nbuilding/N-lang#245.
 
 ## Lists

--- a/docs/features/operators.md
+++ b/docs/features/operators.md
@@ -56,7 +56,7 @@ When the inputs are ints it will return an int which is the mathematical additio
 let val = 1 + 2 // 3
 ```
 
-When the inputs are floats it will return a float which is the mathematical addidtion of the two numbers: 
+When the inputs are floats it will return a float which is the mathematical addition of the two numbers: 
 ```js
 let val = 1.5 + 2.5 // 4.0
 ```

--- a/docs/features/operators.md
+++ b/docs/features/operators.md
@@ -1,0 +1,206 @@
+# Operators
+
+Operators are very useful for manipulating values, this will go though all of the operators currently in N:
+
+### `OR`
+The OR operator (`||` or `|`) can be used on two booleans or two ints, it will either output a bool or a int depending on its inputs.
+
+When the inputs are booleans it will return true if one of the values are `true`, the `||` variation is the standard for bools:
+```js
+let val = true || false // true
+
+let val1 = false || false // false
+```
+
+When the inputs are ints it will return an int that has all of the bits combined, the `|` variation is the standard for ints:
+```js
+let val1 = 0b1100 // 12
+let val2 = 0b0111 // 7
+
+let val = val1 | val2 // 15 or:
+/*
+  1100
+| 0111 =
+  1111
+*/
+```
+
+### `AND`
+The AND operator (`&&` or `&`) can be used on two booleans or two ints, it will either output a bool or a int depending on its inputs.
+
+When the inputs are booleans it will return true if both of the values are `true`, the `&&` variation is the standard for bools:
+```js
+let val = true || false // true
+
+let val1 = false || false // false
+```
+
+When the inputs are ints it will return an int that has all of the bits combined, the `&` variation is the standard for ints:
+```js
+let val1 = 0b1100 // 12
+let val2 = 0b0111 // 7
+
+let val = val1 & val2 // 4 or:
+/*
+  1100
+& 0111 =
+  0100
+*/
+```
+
+### `ADD`
+The ADD operator (`+`) can be used on ints, floats, chars, and strings to combine or mathematically add them together.
+
+When the inputs are ints it will return an int which is the mathematical addition of the two numbers:
+```js
+let val = 1 + 2 // 3
+```
+
+When the inputs are floats it will return a float which is the mathematical addidtion of the two numbers: 
+```js
+let val = 1.5 + 2.5 // 4.0
+```
+
+When the inputs are both strings it will return a string which is the concatination of both of the strings:
+```js
+let val = "hel" + "llo" // "hello"
+```
+
+When one of the inputs are a string and another is a char it will take the string version of the char and concatenate them:
+```js
+let val = \{h} + "ello" // "hello"
+```
+
+### `SUBTRACT`
+The SUBTRACT operator (`-`) can be used on ints and floats as a sign to signal a number as negative or as a mathematical expression
+
+When the inputs are both ints it will return an int which is the mathematical subtraction of the two numbers:
+```js
+let val = 2 - 1 // 1
+
+let val1 = -1 // -1
+```
+
+When the inputs are both floats it will return a float which is the mathematical subtraction of the two numbers:
+```js
+let val = 2.5 - 0.5 // 2.0
+
+let val1 = -1.5 // -1.5
+```
+
+### `MULTIPLY`
+The MULTIPLY operator (`*`) can be used on ints and floats as a mathematical expression
+
+When the inputs are both ints it will return an int which is the mathematical multiplication of the two numbers:
+```js
+let val = 2 * 3 // 6
+```
+
+When the inputs are both floats it will return a float which is the mathematical multiplication of the two numbers:
+```js
+let val = 2.5 * 0.5 // 1.25
+```
+
+### `DIVIDE`
+The DIVIDE operator (`/`) can be used on ints and floats as a mathematical expression
+
+When the inputs are both ints it will return an int which is the mathematical division of the two numbers and it will truncate the number:
+```js
+let val = 7 / 4 // 3
+```
+
+When the inputs are both floats it will return a float which is the mathematical division of the two numbers:
+```js
+let val = 2.5 / 0.5 // 5.0
+```
+
+### `SHIFTL` and `SHIFTR`
+The SHIFTL (`>>`) and SHIFTR (`<<`) operators take in two ints and will bit shift the int on the left the amount of times as the number on the right:
+```js
+let val = 1 << 3 // 0100 from 0001 or 4
+
+let val1 = 8 >> 2 // 0010 from 1000 or 2
+```
+
+### `IN`
+The IN operator (`in`) can be used on values in lists, chars, and strings to measure whether a value is in them.
+
+When the values given are a list and a item whose type is type of the values in the list it will return `true` if the item is in the list:
+```js
+let val = 1 in [1, 2, 3, 4] // true
+```
+
+When the values given are a char and a string or a string and a string it will return true if the char or the string is inside the string:
+```js
+let val = \{e} in "hello" // true
+
+let val1 = "hi" in "hello" // false
+```
+
+### `MODULO`
+The MODULO operator (`%`) can be used to get the remainder of a division between ints or floats
+
+When the values given are ints then it will return the remainder of a division between those two ints:
+```js
+let val = 12 % 5 // 2
+```
+
+When the values given are floats then it will return the reaminder of a division between those floats as a float:
+```js
+let val = 1.5 % 1.0 // 0.5
+```
+
+### `EXPONENT`
+The EXPONENT operator (`^`) can be used to get the exponent of two ints or two floats
+
+When the values given are ints it will return the exponent of both as a float to account for negative exponents:
+```js
+let val = 2^3 // 8.0
+```
+
+When the values given are floats it will return the exponent of both as a float:
+```js
+let val = 1.5 ^ 2.0 // 2.25
+```
+
+### `VALUEACCESS`
+The VALUEACCESS operator (`[` x `]`) can be used to get items from lists, maps, and the `maybe` variations of each
+
+When the values given are a list and and int it will return the item in the index of the list as a `maybe`, if it cannot get that item it will return a `none`:
+```js
+let val = [1, 2, 3, 4][0] // yes(1)
+
+let val1 = [1, 2, 3, 4][10] // none
+```
+
+When the values given are a map and a value of its key type it will return the item associated with that key as a `maybe` if the key does not exist it will return `none`:
+```js
+let m = mapFrom([
+	(1, "one"),
+	(2, "two")
+])
+
+let val = m[1] // yes("one")
+
+let val1 = m[10] // none
+```
+
+When the values given are a `maybe` it will run as normal if the value is not a `none` but if it is a `none` then it will return `none`:
+```js
+let m = mapFrom([
+	(1, [1, 2, 3]),
+	(2, [2, 3, 4])
+])
+
+let val = m[1][0] // yes(1)
+
+let val = m[1][10] // none
+
+let val1 = m[10][0] // none
+```
+
+### `NOT`
+The NOT operator (`~` or `not`) takes in a bool invert the bool:
+```js
+let val = ~true // false
+```

--- a/docs/features/operators.md
+++ b/docs/features/operators.md
@@ -166,7 +166,7 @@ let val = 1.5 ^ 2.0 // 2.25
 ### `VALUEACCESS`
 The VALUEACCESS operator (`[` x `]`) can be used to get items from lists, maps, and the `maybe` variations of each
 
-When the values given are a list and and int it will return the item in the index of the list as a `maybe`, if it cannot get that item it will return a `none`:
+When the values given are a list and an int it will return the item in the index of the list as a `maybe`, if it cannot get that item it will return a `none`:
 ```js
 let val = [1, 2, 3, 4][0] // yes(1)
 

--- a/docs/features/operators.md
+++ b/docs/features/operators.md
@@ -115,7 +115,7 @@ let val = 2.5 / 0.5 // 5.0
 ```
 
 ### `SHIFTL` and `SHIFTR`
-The SHIFTL (`>>`) and SHIFTR (`<<`) operators take in two ints and will bit shift the int on the left the amount of times as the number on the right:
+The SHIFTL (`>>`) and SHIFTR (`<<`) operators take in two ints and will bit shift the int on the left the number of times as the number on the right:
 ```js
 let val = 1 << 3 // 0100 from 0001 or 4
 

--- a/docs/features/operators.md
+++ b/docs/features/operators.md
@@ -66,7 +66,7 @@ When the inputs are both strings it will return a string which is the concatenat
 let val = "hel" + "llo" // "hello"
 ```
 
-When one of the inputs are a string and another is a char it will take the string version of the char and concatenate them:
+When one of the inputs is a string and another is a char it will take the string version of the char and concatenate them:
 ```js
 let val = \{h} + "ello" // "hello"
 ```

--- a/docs/features/operators.md
+++ b/docs/features/operators.md
@@ -26,7 +26,7 @@ let val = val1 | val2 // 15 or:
 ```
 
 ### `AND`
-The AND operator (`&&` or `&`) can be used on two booleans or two ints, it will either output a bool or a int depending on its inputs.
+The AND operator (`&&` or `&`) can be used on two booleans or two ints, it will either output a bool or an int depending on its inputs.
 
 When the inputs are booleans it will return true if both of the values are `true`, the `&&` variation is the standard for bools:
 ```js

--- a/docs/features/operators.md
+++ b/docs/features/operators.md
@@ -3,7 +3,7 @@
 Operators are very useful for manipulating values, this will go through all of the operators currently in N:
 
 ### `OR`
-The OR operator (`||` or `|`) can be used on two booleans or two ints, it will either output a bool or a int depending on its inputs.
+The OR operator (`||` or `|`) can be used on two booleans or two ints, it will either output a bool or an int depending on its inputs.
 
 When the inputs are booleans it will return true if one of the values are `true`, the `||` variation is the standard for bools:
 ```js

--- a/docs/features/operators.md
+++ b/docs/features/operators.md
@@ -145,7 +145,7 @@ When the values given are ints then it will return the remainder of a division b
 let val = 12 % 5 // 2
 ```
 
-When the values given are floats then it will return the reaminder of a division between those floats as a float:
+When the values given are floats then it will return the remainder of a division between those floats as a float:
 ```js
 let val = 1.5 % 1.0 // 0.5
 ```

--- a/docs/features/operators.md
+++ b/docs/features/operators.md
@@ -1,6 +1,6 @@
 # Operators
 
-Operators are very useful for manipulating values, this will go though all of the operators currently in N:
+Operators are very useful for manipulating values, this will go through all of the operators currently in N:
 
 ### `OR`
 The OR operator (`||` or `|`) can be used on two booleans or two ints, it will either output a bool or a int depending on its inputs.

--- a/docs/features/operators.md
+++ b/docs/features/operators.md
@@ -61,7 +61,7 @@ When the inputs are floats it will return a float which is the mathematical addi
 let val = 1.5 + 2.5 // 4.0
 ```
 
-When the inputs are both strings it will return a string which is the concatination of both of the strings:
+When the inputs are both strings it will return a string which is the concatenation of both of the strings:
 ```js
 let val = "hel" + "llo" // "hello"
 ```

--- a/docs/features/tuples_lists_records.md
+++ b/docs/features/tuples_lists_records.md
@@ -1,6 +1,6 @@
 # Tuples, Lists, and Records
 
-Tuples, lists, and records are all types that store multiple values, each of them all have their own use. Let us start with tuples, tuples are values that can store a set amount of values of different types. The main way to recover the values are to destructure the tuple. Here is an example of a tuple value:
+Tuples, lists, and records are all types that store multiple values, each of them all have their own use. Let us start with tuples, tuples are values that can store a set amount of values of different types. The main way to recover the values is to destructure the tuple. Here is an example of a tuple value:
 ```js
 // This will declare a simple tuple with a int and a char
 let tuplevalue:(int, char) = (1, \{a})

--- a/docs/features/tuples_lists_records.md
+++ b/docs/features/tuples_lists_records.md
@@ -24,6 +24,42 @@ let listindexvalue = itemAt(1, listvalue) // This returns a maybe which will nee
 
 print(listindexvalue)
 ```
+To edit a record or set an item in a list you are able to use the `..` operator, here is an example of its use:
+```js
+let listvalue:list[str] = ["a", "b", "c"]
+
+print([..listvalue, "d"]) // prints out ["a", "b", "c", "d"]
+```
+The `..` operator works by inserting all of the items in the list that it is used on into the list literal, for example a `[..["a", "b"], "c", ..["d"]]` will evaluate to a `["a", "b", "c", "d"]`. For records it works a bit different, you are able to override fields in records by inserting them later as so:
+```js
+let recordvalue: { value1: int; value2: str } = {
+	value1: 1
+	value2: "2"
+}
+
+print({
+	..recordvalue
+	value1: 2
+}) // prints out { value1: 2; value2: "2" }
+```
+The `..` operator can even be used with two records to create a new one:
+```js
+let recordvalue: { value1: int; value2: str } = {
+	value1: 1
+	value2: "2"
+}
+
+let recordvalue1: { value2: str; value3: bool } = {
+	value2: "3"
+	value3: false
+}
+
+print({
+	..recordvalue
+	..recordvalue1
+}) // prints out { value1: 1; value2: "3"; value3: false }
+```
+
 
 ## Notes:
 - All of the above can be [destructured](./destructuring.md).

--- a/docs/features/tuples_lists_records.md
+++ b/docs/features/tuples_lists_records.md
@@ -1,15 +1,20 @@
 # Tuples, Lists, and Records
 
+Tuples, lists, and records are all types that store multiple values, each of them all have their own use. Let us start with tuples, tuples are values that can store a set amount of values of different types. The main way to recover the values are to destructure the tuple. Here is an example of a tuple value:
 ```js
 // This will declare a simple tuple with a int and a char
 let tuplevalue:(int, char) = (1, \{a})
-
+```
+This makes a simple tuple with an `int` and a `char`. Next let us take a look at records, records are used to store certain types and assign a name or key to each value, allowing for easier and more human understandable useage like so:
+```js
 // This will declare a record with a int called value and then get that from it
 let recordvalue:{ value: int } = {
 	value: 1 // There is either a newline or ; at the end
 }
 let value = recordvalue.value
-
+```
+Here this simply makes a record with one value, but a record can also be used as a simpler way or storing class-like data, without the useage of a class. Lastly is a list, which takes in a type and stores a list of values of that type, there is no limit to how many items a data can hold, here is and example of a list in action:
+```js
 // This will declare a list of strings
 let listvalue:list[str] = ["a", "b", "c"]
 

--- a/docs/features/tuples_lists_records.md
+++ b/docs/features/tuples_lists_records.md
@@ -7,7 +7,7 @@ let tuplevalue:(int, char) = (1, \{a})
 ```
 This makes a simple tuple with an `int` and a `char`. Next, let us take a look at records, records are used to store certain types and assign a name or key to each value, allowing for easier and more human-understandable usage like so:
 ```js
-// This will declare a record with a int called value and then get that from it
+// This will declare a record with an int called value and then get that from it
 let recordvalue:{ value: int } = {
 	value: 1 // There is either a newline or ; at the end
 }

--- a/docs/features/tuples_lists_records.md
+++ b/docs/features/tuples_lists_records.md
@@ -5,7 +5,7 @@ Tuples, lists, and records are all types that store multiple values, each of the
 // This will declare a simple tuple with a int and a char
 let tuplevalue:(int, char) = (1, \{a})
 ```
-This makes a simple tuple with an `int` and a `char`. Next let us take a look at records, records are used to store certain types and assign a name or key to each value, allowing for easier and more human understandable useage like so:
+This makes a simple tuple with an `int` and a `char`. Next, let us take a look at records, records are used to store certain types and assign a name or key to each value, allowing for easier and more human-understandable usage like so:
 ```js
 // This will declare a record with a int called value and then get that from it
 let recordvalue:{ value: int } = {

--- a/docs/features/tuples_lists_records.md
+++ b/docs/features/tuples_lists_records.md
@@ -13,7 +13,7 @@ let recordvalue:{ value: int } = {
 }
 let value = recordvalue.value
 ```
-Here this simply makes a record with one value, but a record can also be used as a simpler way or storing class-like data, without the useage of a class. Lastly is a list, which takes in a type and stores a list of values of that type, there is no limit to how many items a data can hold, here is and example of a list in action:
+Here this simply makes a record with one value, but a record can also be used as a simpler way of storing class-like data, without the usage of a class. Lastly is a list, which takes in a type and stores a list of values of that type, there is no limit to how many items a data can hold, here is an example of a list in action:
 ```js
 // This will declare a list of strings
 let listvalue:list[str] = ["a", "b", "c"]

--- a/docs/features/variables.md
+++ b/docs/features/variables.md
@@ -1,21 +1,129 @@
 # Variables
 
+Like in mathematics and many programming languages, N has variables that allow
+you to store values of any type under a variable name.
+
+In N, all variables are constants. This means that their value, once set, will
+never change. This makes N programs reliable because you can trust that a
+function can be run multiple times without behaving differently, and this allows
+N programs to be multi-threaded without running into issues with race
+conditions. <!-- This might seem odd, especially for users coming from some
+programming languages, because "variable" implies that the variable should be
+variable, or changeable. However, like in math, "variable" in this sense implies
+that the value itself at runtime is variable. -->
+
+## `let` statements
+
+To create a variable, you can use the `let` statement. The keyword `let` is
+followed by the variable name, a colon (`:`), the type of the variable (called
+the type annotation), an equals sign (`=`), and the expression whose evaluated
+result should be stored in the variable. In the following example, we set a
+variable named `name` to the string `"Billy"`, and we indicate that `name` is of
+the `str` type.
+
 ```js
-// Declare a string that has the value "test"
-let test:str = "test"
-
-// Types can be inferred
-let test2 = 1
-
-print(test)
-print(test2)
-
-// You can change the values of variables, but this is discouraged
-var test = "hi"
-
-print(test)
+let name: str = 'Billy'
 ```
 
-## Notes:
-- `var` does not need a type after the name
-- `type` was used to get the type of a variable but is now depricated.
+In many cases, however, the type can be inferred, so the type annotation can be
+omitted. The above code can be simplified to the following:
+
+```js
+let name = 'Billy'
+```
+
+You can use a [definite pattern](./destructuring.md) in a `let` statement to
+extract values from various types of values, such as records and tuples.
+
+```js
+let { name; age: yearsSinceBirth } = {
+  name: "Billy"
+  age: 36
+}
+
+assert value (name, yearsSinceBirth) == ("Billy", 36)
+```
+
+Learn more about definite patterns at [Patterns](./destructuring.md).
+
+### Exporting variables
+
+In a module, you can export a variable by adding the `pub` keyword after `let`. For example, the following exports a variable named `wow` from the module,
+making it accessible by other modules.
+
+```js
+// a.n
+
+let pub a = "aaaaaa"
+```
+
+```js
+// b.n
+
+let aModule = imp "./a.n"
+
+assert value aModule.a == "aaaaaa"
+```
+
+Learn more about exporting values at [Importing .n
+files](./importing_n_files.md).
+
+## Other ways of creating variables
+
+`let` statements aren't the only way variables can be defined.
+
+Function arguments can also store the argument values given to the function by a
+function call. [Definite patterns](./destructuring.md) can also be used in
+function arguments. Notably, however, type annotations are required for function
+arguments.
+
+For example, in the following example, `name` and `age` are usable like
+variables inside the `displayPerson` function.
+
+```js
+let displayPerson = [(name, age): (str, int)] -> str {
+  return name + ", a " + intInBase10(age) + "-year-old neckbeard"
+}
+
+assert value displayPerson(("Billy", 36)) == "Billy, a 36-year-old neckbeard"
+```
+
+Variables are also created by conditional patterns in [`if let`](./if_statements.md#if-let) statements and expressions. In the following
+example, `text` is usable like a variable containing a string.
+
+```js
+if let <yes text> = yes("hello") {
+  assert value text == "hello"
+}
+```
+
+## `var` statements
+
+N has a `var` statement to change the values of variables. However, its
+behaviour is not defined, so its use is strongly discouraged. Its syntax only
+remains in N to maintain backwards compatibility.
+
+```js
+class Test {
+  let pub property = 3
+
+  let pub change = [] -> () {
+    var property = 4
+  }
+}
+
+let function = [a:int] -> () {
+  var a = 2
+}
+
+let n = 1
+function(n)
+print(n)
+
+let test = Test()
+test.change()
+print(test.property)
+```
+
+The following program could print first either `1` or `2` then either `3` or
+`4`. Any N implementation is free to decide what `var` does.

--- a/docs/features/variables.md
+++ b/docs/features/variables.md
@@ -100,8 +100,8 @@ if let <yes text> = yes("hello") {
 ## `var` statements
 
 N has a `var` statement to change the values of variables. However, its
-behaviour is not defined, so its use is strongly discouraged. Its syntax only
-remains in N to maintain backwards compatibility.
+behavior is not defined, so its use is strongly discouraged. Its syntax only
+remains in N to maintain backward compatibility.
 
 ```js
 class Test {

--- a/docs/features/while.md
+++ b/docs/features/while.md
@@ -11,7 +11,7 @@ while (true) {
 	print("hi")
 }
 ```
-This ends up filling the screen with `hi`, but it can also be used for more productive measures as well.
+This ends up filling the screen with `hi`, but it can be used for more productive measures as well.
 
 Break is used in while loops, for loops, and if statements to break out of them whenever it is needed, here is an example:
 ```js

--- a/docs/features/while.md
+++ b/docs/features/while.md
@@ -1,0 +1,44 @@
+# While, break, and continue
+
+While loops are great for running a peice of code over and over again until a condition is met, here is one that waits for the user to type hello:
+```js
+while ( SystemIO.inp("Please type `hello`: ")! /= "hello" ) {}
+```
+
+The other main situations while loops find themselves in are times when a user wants to run a set of code indefinitely:
+```js
+while (true) {
+	print("hi")
+}
+```
+This ends up filling the screen with `hi`, but it can also be used for more productive measures as well.
+
+Break is used in while loops, for loops, and if statements to break out of them whenever it is needed, here is an example:
+```js
+while (true) {
+	if (SystemIO.inp("Please type `hello`: ")! == "hello") {
+		break
+	}
+}
+```
+Here it is the exact same effect as the first example but it is a lot more readable, break can also be used to cut off for loops
+```js
+for (i in range(0, 10, 1)) {
+	if (i == 5) {
+		break
+	}
+	print(i)
+}
+```
+This will now only count until 4, as it breaks when it gets to 5.
+
+Continue is used to skip over the rest of a loop when called, it can be used in for loops to skip certain items:
+```js
+for (i in range(0, 10, 1)) {
+	if (i == 5) {
+		continue
+	}
+	print(i)
+}
+```
+Now, instead of stopping once it reaches 5, it just skips printing out the number 5, but continues to 6, 7, 8, and 9. This can also be done with while loops as well.

--- a/docs/features/while.md
+++ b/docs/features/while.md
@@ -1,6 +1,6 @@
 # While, break, and continue
 
-While loops are great for running a peice of code over and over again until a condition is met, here is one that waits for the user to type hello:
+While loops are great for running a piece of code over and over again until a condition is met, here is one that waits for the user to type hello:
 ```js
 while ( SystemIO.inp("Please type `hello`: ")! /= "hello" ) {}
 ```


### PR DESCRIPTION
- [x] `aliases`
- [x] `assert`
- [x] `async`
- [x] `classes`
- [x] `currying`
- [x] `destructuring`
- [x] `enums`
- [x] `for_loops`
- [x] `functions`
- [x] `generic`
- [x] `if_statements`
- [x] `importing_n_files`
- [x] `internal_libraries`
- [x] `literals`
- [x] `match`
- [x] `native_functions`
- [x] `operators`
- [x] `tuples_lists_records` (`..` operator)
- [x] `variables`
- [x] `while`